### PR TITLE
WAT-103: Malformed TOML falls back to defaults; never panic

### DIFF
--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,7 +1,7 @@
 pub mod settings;
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use directories::ProjectDirs;
 use crate::config::settings::Settings;
 
@@ -14,6 +14,45 @@ pub fn get_config_path() -> Option<PathBuf> {
     get_config_dir().map(|dir| dir.join("config.toml"))
 }
 
+/// Parse TOML content into `Settings`. On parse failure — malformed syntax,
+/// truncated file, wrong type, missing required section — log a warning and
+/// fall back to `Settings::default()`. Never panics.
+///
+/// WAT-103 (R-14 mitigation): a corrupted or hand-edited `config.toml` must
+/// not brick startup. Earlier versions used `toml::from_str(..).unwrap_or_default()`
+/// which swallowed the error silently; users had no signal that their edit
+/// didn't take. This function surfaces the error on stderr until WAT-406
+/// (notifications drawer) can render it in-app.
+pub fn parse_settings(content: &str) -> Settings {
+    match toml::from_str::<Settings>(content) {
+        Ok(settings) => settings,
+        Err(e) => {
+            eprintln!(
+                "watson: failed to parse config.toml ({e}); falling back to default settings"
+            );
+            Settings::default()
+        }
+    }
+}
+
+/// Load settings from an explicit path. Returns `Settings::default()` if the
+/// file is missing or unreadable. Used by tests and by `load_settings()`.
+pub fn load_settings_from(path: &Path) -> Settings {
+    if !path.exists() {
+        return Settings::default();
+    }
+    match fs::read_to_string(path) {
+        Ok(content) => parse_settings(&content),
+        Err(e) => {
+            eprintln!(
+                "watson: failed to read config at {}: {e}; falling back to default settings",
+                path.display()
+            );
+            Settings::default()
+        }
+    }
+}
+
 pub fn load_settings() -> Settings {
     let path = match get_config_path() {
         Some(p) => p,
@@ -21,15 +60,13 @@ pub fn load_settings() -> Settings {
     };
 
     if !path.exists() {
+        // First run: persist defaults so the user has something to edit.
         let settings = Settings::default();
         let _ = save_settings(&settings);
         return settings;
     }
 
-    match fs::read_to_string(&path) {
-        Ok(content) => toml::from_str(&content).unwrap_or_default(),
-        Err(_) => Settings::default(),
-    }
+    load_settings_from(&path)
 }
 
 pub fn save_settings(settings: &Settings) -> Result<(), String> {

--- a/src-tauri/src/config/tests.rs
+++ b/src-tauri/src/config/tests.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
+    use crate::config::{load_settings_from, parse_settings};
     use crate::config::settings::Settings;
     use std::collections::HashSet;
+    use tempfile::TempDir;
 
     /// Prefixes reserved by the search dispatcher in `lib.rs::search`.
     /// A web-search keyword colliding with one of these silently shadows
@@ -62,5 +64,168 @@ mod tests {
                 ws.keyword,
             );
         }
+    }
+
+    // --- WAT-103: malformed TOML fallback ---
+    //
+    // Every branch in these tests ends with a valid `Settings` value. The
+    // regression we're guarding against is a prior behavior where
+    // `unwrap_or_default` swallowed the parse error silently, and a bad edit
+    // could also cause startup panics in debug builds. The contract now:
+    // malformed input → defaults, no panic, error logged to stderr.
+
+    #[test]
+    fn parse_settings_returns_defaults_on_empty_input() {
+        // An empty file fails to satisfy any required struct field; must not
+        // panic. The `activation.hotkey` assertion proves we landed on
+        // `Settings::default()` rather than some partially-populated state.
+        let settings = parse_settings("");
+        assert_eq!(settings.activation.hotkey, "Alt+Space");
+    }
+
+    #[test]
+    fn parse_settings_returns_defaults_on_truncated_input() {
+        // File was cut mid-array — classic hand-edit accident.
+        let broken = r#"
+[general]
+launch_at_login = true
+
+[search]
+max_results = 8
+web_searches = [
+  { name = "Google", keyword = "g", url = "https://www.google.com/search?q={query}"
+"#;
+        let settings = parse_settings(broken);
+        // Full fallback: every default value is present, nothing from the
+        // partial input leaked through.
+        assert_eq!(settings.search.max_results, 8);
+        assert!(settings.general.launch_at_login);
+        assert!(
+            !settings.web_searches.is_empty(),
+            "default web searches should be present when parse fails"
+        );
+    }
+
+    #[test]
+    fn parse_settings_returns_defaults_on_missing_required_section() {
+        // `[general]`, `[activation]`, `[search]`, `[theme]` are required
+        // top-level sections. Missing any one of them → whole parse fails →
+        // full defaults. (Field-level fallback would require custom
+        // Deserialize impls — a separate ticket.)
+        let partial = r#"
+[activation]
+hotkey = "Alt+Space"
+show_tray_icon = true
+"#;
+        let settings = parse_settings(partial);
+        // If parse had succeeded, hotkey from the file would survive and
+        // launch_at_login would come from serde default. Since it fails, we
+        // get full defaults — both values come from Settings::default().
+        assert!(settings.general.launch_at_login);
+    }
+
+    #[test]
+    fn parse_settings_returns_defaults_on_wrong_type() {
+        // Hand-edited "max_results = 'eight'" — number field quoted as string.
+        // TOML parse succeeds syntactically; serde fails on the type. Must
+        // fall back, not crash.
+        let bad_type = r#"
+[general]
+launch_at_login = true
+
+[activation]
+hotkey = "Alt+Space"
+show_tray_icon = true
+
+[search]
+max_results = "eight"
+show_recently_used = true
+fuzzy_match_threshold = 0.6
+
+[theme]
+mode = "system"
+accent_color = "system"
+"#;
+        let settings = parse_settings(bad_type);
+        assert_eq!(settings.search.max_results, 8);
+    }
+
+    #[test]
+    fn parse_settings_ignores_unknown_top_level_keys() {
+        // Forward-compat: a config written by a newer Watson with fields we
+        // don't know about must still parse. serde's default for structs is
+        // "ignore unknown fields" (we do NOT set deny_unknown_fields); pin
+        // that behavior so no one accidentally tightens it.
+        let with_extra = r#"
+future_feature = "enabled"
+
+[general]
+launch_at_login = false
+
+[activation]
+hotkey = "Alt+Space"
+show_tray_icon = true
+
+[search]
+max_results = 12
+show_recently_used = true
+fuzzy_match_threshold = 0.6
+
+[theme]
+mode = "dark"
+accent_color = "blue"
+"#;
+        let settings = parse_settings(with_extra);
+        // Real values from the file survive; no fallback triggered.
+        assert_eq!(settings.search.max_results, 12);
+        assert_eq!(settings.theme.mode, "dark");
+        assert!(!settings.general.launch_at_login);
+    }
+
+    #[test]
+    fn parse_settings_succeeds_on_a_full_valid_config() {
+        // Negative-control: defaults serialized + parsed round-trips cleanly.
+        // If this test ever fails, parse_settings itself is broken, not the
+        // fallback path.
+        let defaults = Settings::default();
+        let serialized = toml::to_string_pretty(&defaults).expect("serialize defaults");
+        let parsed = parse_settings(&serialized);
+        assert_eq!(parsed.search.max_results, defaults.search.max_results);
+        assert_eq!(parsed.activation.hotkey, defaults.activation.hotkey);
+        assert_eq!(parsed.web_searches.len(), defaults.web_searches.len());
+    }
+
+    #[test]
+    fn load_settings_from_returns_defaults_for_missing_file() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("never-created.toml");
+        let settings = load_settings_from(&missing);
+        assert_eq!(settings.activation.hotkey, "Alt+Space");
+    }
+
+    #[test]
+    fn load_settings_from_returns_defaults_for_malformed_file() {
+        // End-to-end: a real file with bad contents produces defaults, not
+        // a panic.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "this is not valid toml = [").unwrap();
+        let settings = load_settings_from(&path);
+        assert_eq!(settings.activation.hotkey, "Alt+Space");
+    }
+
+    #[test]
+    fn load_settings_from_round_trips_a_saved_config() {
+        // Pin the serialize → write → read → parse chain. If the TOML
+        // emitter ever drifts from the deserializer, this catches it.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut settings = Settings::default();
+        settings.search.max_results = 42;
+        let content = toml::to_string_pretty(&settings).unwrap();
+        std::fs::write(&path, content).unwrap();
+
+        let loaded = load_settings_from(&path);
+        assert_eq!(loaded.search.max_results, 42);
     }
 }


### PR DESCRIPTION
## Summary
- `parse_settings(content)` now logs the parse error and falls back to `Settings::default()` instead of `unwrap_or_default`'s silent swallow.
- `load_settings_from(path)` extracted so tests and future callers work against explicit paths (no `ProjectDirs`).
- 9 new tests pin the fallback contract across: empty, truncated, missing-section, wrong-type, unknown-top-level-key, valid round-trip, missing file, malformed on-disk file, save-then-load.

Closes #5. Tracks TA-13 from the test-design doc; mitigates R-14.

## Why
A user hand-editing `config.toml` (or a future Watson writing a field we can't read) must never brick startup. The old `unwrap_or_default` silently replaced their entire config on any error; worse, users had no signal their edit didn't take. Now: error goes to stderr; config folder preserved; app launches with defaults.

## Forward-compat property
Serde's default behavior of ignoring unknown struct fields is now pinned by `parse_settings_ignores_unknown_top_level_keys`. If anyone adds `#[serde(deny_unknown_fields)]`, that test flags the break. This matters for the future — v1.4 adding a new field should not make v1.3 configs unreadable by v1.3 or vice versa.

## Test plan
- [x] `cargo test` — 162 passed, 0 failed, 1 ignored (local)
- [x] 9 new config tests, listed in the commit message
- [ ] Manual: rename config.toml to `broken.toml`, write \`garbage\`, rename back, relaunch — should start with defaults, stderr has a clear message

## Notes
- No dependency on a logging crate; uses `eprintln!` to match the existing convention in the codebase (only prior user was clipboard's thread-spawn failure path). WAT-406 will migrate these to an in-app notifications drawer.
- Ticket scope was "never panic, always yield valid Settings" — field-level fallback (where one bad field defaults but others persist) would require custom Deserialize impls and is out of scope; filed mentally as a follow-up if anyone actually hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)