### PR TITLE
WAT-105: Surface shortcut-registration failures to UI

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod indexers;
 mod notes;
 mod scratchpad;
 mod search;
+mod warnings;
 
 use actions::system::{execute_command, get_system_commands};
 use clipboard::ClipboardManager;
@@ -14,6 +15,7 @@ use config::settings::Settings;
 use files::{FileEntry, FileSearchManager, indexer::FileIndexer};
 use notes::NotesManager;
 use scratchpad::ScratchpadManager;
+use warnings::{StartupWarning, StartupWarnings};
 use db::{AppEntry, Database};
 use indexers::{get_indexer, AppIndexer};
 use search::dispatch::{classify_prefix_route, match_web_search, Route, SubQuery, WebSearchMatch};
@@ -38,6 +40,10 @@ struct AppState {
     scratchpad: ScratchpadManager,
     notes: NotesManager,
     file_search: Arc<FileSearchManager>,
+    /// WAT-105: non-fatal conditions that surfaced during `setup()` and
+    /// should be rendered in the UI — e.g., the global hotkey couldn't be
+    /// registered because another app already owns it.
+    startup_warnings: StartupWarnings,
 }
 
 #[tauri::command]
@@ -368,6 +374,20 @@ fn clear_file_index(state: State<AppState>) -> Result<(), String> {
     state.file_search.clear_all()
 }
 
+/// WAT-105: frontend calls this on mount to render a banner for any
+/// non-fatal conditions that surfaced during app setup.
+#[tauri::command]
+fn get_startup_warnings(state: State<AppState>) -> Vec<StartupWarning> {
+    state.startup_warnings.list()
+}
+
+/// WAT-105: dismiss a specific warning by id. Returns true if something was
+/// removed; dismissing an unknown id is not an error (UI may race backend).
+#[tauri::command]
+fn dismiss_startup_warning(id: String, state: State<AppState>) -> bool {
+    state.startup_warnings.dismiss(&id)
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let db = Arc::new(Database::new().expect("Failed to initialize database"));
@@ -403,15 +423,24 @@ pub fn run() {
             scratchpad,
             notes,
             file_search,
+            startup_warnings: StartupWarnings::new(),
         })
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
 
             // Register global shortcut (Alt+Space)
+            // WAT-105 / R-11: registration can fail (hotkey already bound
+            // by another app, platform restriction, no keyboard daemon on
+            // some Linux WMs). Historically `?` here aborted Tauri setup
+            // entirely, leaving the user with a window that silently
+            // didn't respond to the hotkey. Now: capture the error as a
+            // startup warning and keep launching so the user can open the
+            // app via the tray or CLI and rebind.
             let shortcut = Shortcut::new(Some(Modifiers::ALT), Code::Space);
+            let hotkey_label = "Alt+Space";
             let hotkey_window = window.clone();
 
-            app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
+            if let Err(e) = app.global_shortcut().on_shortcut(shortcut, move |_app, _shortcut, event| {
                 if event.state == ShortcutState::Pressed {
                     if hotkey_window.is_visible().unwrap_or(false) {
                         hotkey_window.hide().ok();
@@ -420,7 +449,13 @@ pub fn run() {
                         hotkey_window.set_focus().ok();
                     }
                 }
-            })?;
+            }) {
+                eprintln!("watson: failed to register hotkey {hotkey_label}: {e}");
+                let state: State<AppState> = app.state();
+                state
+                    .startup_warnings
+                    .record_shortcut_unavailable(hotkey_label, &e.to_string());
+            }
 
             // Create system tray (macOS and Windows only - Linux requires appindicator)
             #[cfg(not(target_os = "linux"))]
@@ -476,7 +511,9 @@ pub fn run() {
             get_recent_files,
             reindex_files,
             cancel_reindex_files,
-            clear_file_index
+            clear_file_index,
+            get_startup_warnings,
+            dismiss_startup_warning
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/warnings.rs
+++ b/src-tauri/src/warnings.rs
@@ -1,0 +1,183 @@
+//! WAT-105 / R-11: startup-time, non-fatal warnings surfaced to the UI.
+//!
+//! Before this module existed, a global-shortcut registration failure
+//! either panicked the Tauri setup closure or was silently dropped — the
+//! user had no way to know their hotkey never registered and the app
+//! appeared unresponsive. Now: failures land here, the app still starts,
+//! and the frontend polls `get_startup_warnings` to render a banner with a
+//! "Change hotkey" escape hatch.
+//!
+//! Keep warnings lightweight. Anything larger (index errors, update
+//! failures) should move into the WAT-406 notifications drawer; the
+//! startup-warnings list is specifically for conditions the app couldn't
+//! recover from during `setup()`.
+
+use serde::{Deserialize, Serialize};
+use std::sync::RwLock;
+
+/// Categories of startup warnings. Kept as a named enum so the frontend
+/// can switch on it for an appropriate call-to-action button.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StartupWarningKind {
+    /// Global hotkey registration failed — usually because the combo is
+    /// already taken by another app (common on some Linux WMs, macOS
+    /// system preferences, Windows apps that bind Alt+Space).
+    ShortcutUnavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StartupWarning {
+    /// Stable id so the UI can dismiss a specific warning without
+    /// accidentally clearing a newer one with the same message.
+    pub id: String,
+    pub kind: StartupWarningKind,
+    /// Human-readable message rendered in the banner verbatim.
+    pub message: String,
+}
+
+#[derive(Debug, Default)]
+pub struct StartupWarnings {
+    inner: RwLock<Vec<StartupWarning>>,
+}
+
+impl StartupWarnings {
+    pub fn new() -> Self {
+        StartupWarnings::default()
+    }
+
+    pub fn push(&self, warning: StartupWarning) {
+        self.inner.write().unwrap().push(warning);
+    }
+
+    /// Snapshot of all active warnings, cloned so the caller doesn't hold
+    /// the lock across an await boundary (Tauri commands can be async).
+    pub fn list(&self) -> Vec<StartupWarning> {
+        self.inner.read().unwrap().clone()
+    }
+
+    /// Remove a warning by id. Returns true if something was removed.
+    /// Dismissing an unknown id is not an error — the UI may race the
+    /// backend and ask to dismiss a warning that another caller already
+    /// cleared.
+    pub fn dismiss(&self, id: &str) -> bool {
+        let mut inner = self.inner.write().unwrap();
+        let before = inner.len();
+        inner.retain(|w| w.id != id);
+        inner.len() != before
+    }
+
+    /// Convenience constructor for the common case: the global hotkey
+    /// couldn't be bound. Uses a deterministic id so repeated calls for
+    /// the same hotkey replace rather than stack.
+    pub fn record_shortcut_unavailable(&self, hotkey: &str, reason: &str) {
+        let id = format!("shortcut-unavailable:{hotkey}");
+        // Deduplicate: if we already recorded this hotkey, drop the old
+        // entry so the newest reason wins. `dismiss` returns false on
+        // first call; we don't care about its result here.
+        let _ = self.dismiss(&id);
+        self.push(StartupWarning {
+            id,
+            kind: StartupWarningKind::ShortcutUnavailable,
+            message: format!(
+                "Couldn't register hotkey {hotkey}: {reason}. Another app may be using it. \
+                 Pick a different hotkey in Settings."
+            ),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_is_empty() {
+        let w = StartupWarnings::new();
+        assert!(w.list().is_empty());
+    }
+
+    #[test]
+    fn push_is_visible_to_list() {
+        let w = StartupWarnings::new();
+        w.push(StartupWarning {
+            id: "x".into(),
+            kind: StartupWarningKind::ShortcutUnavailable,
+            message: "example".into(),
+        });
+        let list = w.list();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].id, "x");
+    }
+
+    #[test]
+    fn dismiss_by_id_removes_exactly_that_entry() {
+        let w = StartupWarnings::new();
+        w.push(StartupWarning {
+            id: "a".into(),
+            kind: StartupWarningKind::ShortcutUnavailable,
+            message: "".into(),
+        });
+        w.push(StartupWarning {
+            id: "b".into(),
+            kind: StartupWarningKind::ShortcutUnavailable,
+            message: "".into(),
+        });
+
+        assert!(w.dismiss("a"));
+
+        let remaining: Vec<String> = w.list().into_iter().map(|x| x.id).collect();
+        assert_eq!(remaining, vec!["b".to_string()]);
+    }
+
+    #[test]
+    fn dismiss_unknown_id_returns_false_and_does_nothing() {
+        let w = StartupWarnings::new();
+        w.push(StartupWarning {
+            id: "a".into(),
+            kind: StartupWarningKind::ShortcutUnavailable,
+            message: "".into(),
+        });
+        assert!(!w.dismiss("nope"));
+        assert_eq!(w.list().len(), 1);
+    }
+
+    #[test]
+    fn record_shortcut_unavailable_produces_a_deterministic_id() {
+        // Contract: the id is derived from the hotkey string alone. This
+        // matters for the de-dup behavior below and for the frontend's
+        // "dismissed this once, don't resurface" logic (when that lands).
+        let w = StartupWarnings::new();
+        w.record_shortcut_unavailable("Alt+Space", "already bound");
+        let id = w.list()[0].id.clone();
+        assert_eq!(id, "shortcut-unavailable:Alt+Space");
+    }
+
+    #[test]
+    fn record_shortcut_unavailable_dedupes_on_same_hotkey() {
+        // Calling twice with the same hotkey must not stack two banners —
+        // Tauri's setup may retry registration depending on plugin impl.
+        let w = StartupWarnings::new();
+        w.record_shortcut_unavailable("Alt+Space", "reason 1");
+        w.record_shortcut_unavailable("Alt+Space", "reason 2");
+        assert_eq!(w.list().len(), 1);
+        // The newest reason wins.
+        assert!(w.list()[0].message.contains("reason 2"));
+    }
+
+    #[test]
+    fn record_shortcut_unavailable_keeps_different_hotkeys_separate() {
+        let w = StartupWarnings::new();
+        w.record_shortcut_unavailable("Alt+Space", "");
+        w.record_shortcut_unavailable("Ctrl+Shift+P", "");
+        assert_eq!(w.list().len(), 2);
+    }
+
+    #[test]
+    fn dismiss_clears_a_shortcut_warning() {
+        let w = StartupWarnings::new();
+        w.record_shortcut_unavailable("Alt+Space", "");
+        assert!(w.dismiss("shortcut-unavailable:Alt+Space"));
+        assert!(w.list().is_empty());
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { SearchBar } from './components/SearchBar';
 import { ResultsList } from './components/ResultsList';
 import { Scratchpad } from './components/Scratchpad';
 import { NoteEditor } from './components/NoteEditor';
+import { StartupWarningBanner } from './components/StartupWarningBanner';
 import { useAppStore } from './stores/app';
 import type { WebSearch } from './types';
 
@@ -456,6 +457,8 @@ function App() {
         </div>
         <SettingsIcon onClick={() => setShowSettings(!showSettings)} />
       </div>
+
+      <StartupWarningBanner onOpenSettings={() => setShowSettings(true)} />
 
       <SearchBar />
 

--- a/src/components/StartupWarningBanner.tsx
+++ b/src/components/StartupWarningBanner.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+import { useAppStore } from '../stores/app';
+import type { StartupWarning } from '../types';
+
+interface Props {
+  /**
+   * Injected action for "Change hotkey" to keep the banner decoupled from
+   * the Settings panel's open/close state owner. App passes the real
+   * `setShowSettings(true)` wrapper.
+   */
+  onOpenSettings: () => void;
+}
+
+/**
+ * WAT-105: renders a banner for each startup warning surfaced by the Rust
+ * backend. Invisible when there are no warnings. Each banner has a dismiss
+ * button; hotkey-related warnings additionally offer "Change hotkey" which
+ * opens the Settings panel.
+ */
+export function StartupWarningBanner({ onOpenSettings }: Props) {
+  const { startupWarnings, loadStartupWarnings, dismissStartupWarning } = useAppStore();
+
+  useEffect(() => {
+    loadStartupWarnings();
+  }, [loadStartupWarnings]);
+
+  if (startupWarnings.length === 0) return null;
+
+  return (
+    <ul
+      role="alert"
+      aria-live="polite"
+      className="border-b border-[var(--border)] bg-amber-50 dark:bg-amber-900/20"
+    >
+      {startupWarnings.map((warning) => (
+        <WarningRow
+          key={warning.id}
+          warning={warning}
+          onDismiss={() => dismissStartupWarning(warning.id)}
+          onOpenSettings={onOpenSettings}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function WarningRow({
+  warning,
+  onDismiss,
+  onOpenSettings,
+}: {
+  warning: StartupWarning;
+  onDismiss: () => void;
+  onOpenSettings: () => void;
+}) {
+  const isHotkey = warning.kind === 'shortcut_unavailable';
+  return (
+    <li className="flex items-start gap-2 px-4 py-2 text-xs text-amber-900 dark:text-amber-100">
+      <svg
+        className="w-4 h-4 mt-0.5 shrink-0"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        aria-hidden="true"
+      >
+        <path d="M12 9v4m0 4h.01" />
+        <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0Z" />
+      </svg>
+
+      <p className="flex-1 leading-snug">{warning.message}</p>
+
+      {isHotkey && (
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          className="text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap"
+        >
+          Change hotkey
+        </button>
+      )}
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label={`Dismiss warning: ${warning.message}`}
+        className="shrink-0 text-amber-900/60 hover:text-amber-900 dark:text-amber-100/60 dark:hover:text-amber-100"
+      >
+        <svg
+          className="w-4 h-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <path d="M18 6 6 18M6 6l12 12" />
+        </svg>
+      </button>
+    </li>
+  );
+}

--- a/src/components/__tests__/StartupWarningBanner.test.tsx
+++ b/src/components/__tests__/StartupWarningBanner.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { invoke } from '@tauri-apps/api/core';
+import { StartupWarningBanner } from '../StartupWarningBanner';
+import { useAppStore } from '../../stores/app';
+import type { StartupWarning } from '../../types';
+
+const mockInvoke = vi.mocked(invoke);
+
+function resetStore() {
+  useAppStore.setState({
+    query: '',
+    results: [],
+    selectedIndex: 0,
+    settings: null,
+    isLoading: false,
+    showSettings: false,
+    scratchpad: '',
+    scratchpadVisible: false,
+    currentNote: null,
+    noteEditorVisible: false,
+    startupWarnings: [],
+  });
+}
+
+function shortcutWarning(overrides: Partial<StartupWarning> = {}): StartupWarning {
+  return {
+    id: overrides.id ?? 'shortcut-unavailable:Alt+Space',
+    kind: overrides.kind ?? 'shortcut_unavailable',
+    message:
+      overrides.message ??
+      "Couldn't register hotkey Alt+Space: already in use. Pick a different hotkey in Settings.",
+  };
+}
+
+describe('StartupWarningBanner', () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockReset();
+    // Default invoke: no warnings. Individual tests override.
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [] as StartupWarning[];
+      return undefined;
+    });
+  });
+
+  it('renders nothing when there are no warnings', async () => {
+    const { container } = render(<StartupWarningBanner onOpenSettings={() => {}} />);
+    // Let the effect's invoke settle.
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('get_startup_warnings');
+    });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the warning message when the backend returns one', async () => {
+    const warning = shortcutWarning();
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [warning];
+      return undefined;
+    });
+
+    render(<StartupWarningBanner onOpenSettings={() => {}} />);
+
+    expect(await screen.findByText(/couldn't register hotkey alt\+space/i)).toBeInTheDocument();
+  });
+
+  it('shows a "Change hotkey" action for shortcut_unavailable warnings', async () => {
+    const onOpenSettings = vi.fn();
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [shortcutWarning()];
+      return undefined;
+    });
+
+    const user = userEvent.setup();
+    render(<StartupWarningBanner onOpenSettings={onOpenSettings} />);
+
+    const button = await screen.findByRole('button', { name: /change hotkey/i });
+    await user.click(button);
+
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismiss button invokes dismiss_startup_warning and removes the banner', async () => {
+    const warning = shortcutWarning({ id: 'shortcut-unavailable:Ctrl+Space' });
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [warning];
+      if (cmd === 'dismiss_startup_warning') return true;
+      return undefined;
+    });
+
+    const user = userEvent.setup();
+    render(<StartupWarningBanner onOpenSettings={() => {}} />);
+
+    const dismiss = await screen.findByRole('button', {
+      name: /dismiss warning:/i,
+    });
+    await user.click(dismiss);
+
+    expect(mockInvoke).toHaveBeenCalledWith('dismiss_startup_warning', {
+      id: 'shortcut-unavailable:Ctrl+Space',
+    });
+
+    // Optimistic local removal — the warning is gone from the DOM before
+    // the store observes the backend response.
+    expect(screen.queryByText(warning.message)).not.toBeInTheDocument();
+  });
+
+  it("renders multiple warnings side-by-side (one per row) — each with its own dismiss", async () => {
+    const warnings: StartupWarning[] = [
+      shortcutWarning({ id: 'a', message: 'first' }),
+      shortcutWarning({ id: 'b', message: 'second' }),
+    ];
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return warnings;
+      return undefined;
+    });
+
+    render(<StartupWarningBanner onOpenSettings={() => {}} />);
+
+    expect(await screen.findByText('first')).toBeInTheDocument();
+    expect(await screen.findByText('second')).toBeInTheDocument();
+    const dismissButtons = await screen.findAllByRole('button', {
+      name: /dismiss warning:/i,
+    });
+    expect(dismissButtons).toHaveLength(2);
+  });
+
+  it('uses role="alert" with aria-live so screen readers announce new warnings', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [shortcutWarning()];
+      return undefined;
+    });
+
+    render(<StartupWarningBanner onOpenSettings={() => {}} />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'polite');
+  });
+});

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
-import type { SearchResult, Settings, Scratchpad, Note } from '../types';
+import type { SearchResult, Settings, Scratchpad, Note, StartupWarning } from '../types';
 
 interface AppState {
   query: string;
@@ -13,6 +13,7 @@ interface AppState {
   scratchpadVisible: boolean;
   currentNote: Note | null;
   noteEditorVisible: boolean;
+  startupWarnings: StartupWarning[];
 
   setQuery: (query: string) => void;
   setSelectedIndex: (index: number) => void;
@@ -35,6 +36,8 @@ interface AppState {
   closeNoteEditor: () => void;
   openNewNote: () => void;
   reindexFiles: () => Promise<number>;
+  loadStartupWarnings: () => Promise<void>;
+  dismissStartupWarning: (id: string) => Promise<void>;
 }
 
 // Height constants
@@ -58,6 +61,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   scratchpadVisible: false,
   currentNote: null,
   noteEditorVisible: false,
+  startupWarnings: [],
 
   setQuery: async (query: string) => {
     set({ query, selectedIndex: 0 });
@@ -278,6 +282,26 @@ export const useAppStore = create<AppState>((set, get) => ({
     } catch (e) {
       console.error('Failed to reindex files:', e);
       return 0;
+    }
+  },
+
+  loadStartupWarnings: async () => {
+    try {
+      const warnings = await invoke<StartupWarning[]>('get_startup_warnings');
+      set({ startupWarnings: warnings });
+    } catch (e) {
+      console.error('Failed to load startup warnings:', e);
+    }
+  },
+
+  dismissStartupWarning: async (id: string) => {
+    // Optimistic update: remove locally first so the banner doesn't linger
+    // while we await the backend confirmation.
+    set({ startupWarnings: get().startupWarnings.filter((w) => w.id !== id) });
+    try {
+      await invoke('dismiss_startup_warning', { id });
+    } catch (e) {
+      console.error('Failed to dismiss startup warning:', e);
     }
   },
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,3 +97,11 @@ export interface FileSearchSettings {
   excluded_patterns: string[];
   max_depth: number;
 }
+
+export type StartupWarningKind = 'shortcut_unavailable';
+
+export interface StartupWarning {
+  id: string;
+  kind: StartupWarningKind;
+  message: string;
+}


### PR DESCRIPTION
## Summary
- New Rust `warnings` module + `StartupWarnings` container threaded through `AppState`.
- `setup()` now captures `on_shortcut` errors into a warning instead of aborting startup via `?`.
- Two new Tauri commands: `get_startup_warnings`, `dismiss_startup_warning`.
- New React `StartupWarningBanner` rendered above `SearchBar` — dismissable, with "Change hotkey" action for the shortcut case. `role="alert"` + `aria-live="polite"` for screen readers.

Closes #7. Mitigates R-11.

## Why
If Alt+Space is already bound (common on some Linux WMs, macOS system prefs, or Windows apps that also claim it), the old setup returned `Err` up through Tauri and either crashed the launcher or left a window that silently didn't respond to the hotkey. Users had no way to know what went wrong.

Now: the app launches with a visible banner explaining the conflict, with a one-click path to change the hotkey in Settings.

## Test plan
- [x] `cargo test` — 161 passed (was 153; +8 warnings tests)
- [x] `npm test` — 21 passed (was 15; +6 banner tests)
- [x] `npm run build` — clean
- [ ] Manual smoke: bind Alt+Space to another app in the OS, launch Watson, verify banner appears; click "Change hotkey" → Settings opens; dismiss X removes the banner and `dismiss_startup_warning` IPC fires.

## Design notes
- `record_shortcut_unavailable` produces a deterministic id keyed on the hotkey string; calling twice for the same hotkey replaces rather than stacks. Prevents duplicate banners if the plugin internally retries.
- The banner is a non-interactive design surface for v1. Once WAT-406 (notifications drawer) lands, these warnings migrate there alongside index/update/permission errors; the API stays the same.
- Frontend dismissal is optimistic — the banner disappears immediately, then the IPC confirms. Dismissing an unknown id is a no-op on the backend, so a race between two tabs/windows is safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)