### PR TITLE
WAT-202: Description-matched search hits no longer silently dropped

### DIFF
--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -42,6 +42,16 @@ pub struct SearchEngine {
     matcher: SkimMatcherV2,
 }
 
+/// WAT-202 / R-09: description-only matches ranked below name matches.
+///
+/// When a query matches an item's description but not its name, we still
+/// want to surface it (previous behavior silently dropped the item). A
+/// 50% multiplier on the description score keeps the relative ordering
+/// within description-only hits while pushing them beneath any name hit
+/// of comparable quality. The exact value isn't load-bearing — it just
+/// has to be <100% so that name-vs-description ties favor the name.
+const DESCRIPTION_SCORE_PENALTY_PERCENT: i64 = 50;
+
 impl SearchEngine {
     pub fn new() -> Self {
         SearchEngine {
@@ -53,11 +63,23 @@ impl SearchEngine {
         self.matcher.fuzzy_match(target, query)
     }
 
+    /// Score an item against the query, considering both `name` and
+    /// `description`. Returns the best of the two (with description
+    /// penalized) or `None` if neither matches.
+    fn score_item(&self, query: &str, name: &str, description: &str) -> Option<i64> {
+        let name_score = self.score(query, name);
+        let description_score = self
+            .score(query, description)
+            .map(|s| s * DESCRIPTION_SCORE_PENALTY_PERCENT / 100);
+        // Option::max returns the higher variant; Some(x).max(None) == Some(x).
+        name_score.max(description_score)
+    }
+
     pub fn search(&self, query: &str, items: Vec<SearchResult>) -> Vec<SearchResult> {
         let mut results: Vec<(SearchResult, i64)> = items
             .into_iter()
             .filter_map(|mut item| {
-                self.score(query, &item.name).map(|score| {
+                self.score_item(query, &item.name, &item.description).map(|score| {
                     item.score = score;
                     (item, score)
                 })

--- a/src-tauri/src/search/tests.rs
+++ b/src-tauri/src/search/tests.rs
@@ -3,10 +3,17 @@ mod tests {
     use crate::search::{ResultType, SearchAction, SearchEngine, SearchResult};
 
     fn item(name: &str) -> SearchResult {
+        // Default description is a string with no overlap with typical
+        // test queries — guarantees existing tests aren't accidentally
+        // lifted by the WAT-202 description-match branch.
+        item_with_description(name, "zzz-test-fixture")
+    }
+
+    fn item_with_description(name: &str, description: &str) -> SearchResult {
         SearchResult {
             id: format!("test:{name}"),
             name: name.to_string(),
-            description: "Test App".into(),
+            description: description.to_string(),
             icon: None,
             result_type: ResultType::Application,
             score: 0,
@@ -66,5 +73,83 @@ mod tests {
                 pair[1].score,
             );
         }
+    }
+
+    // --- WAT-202 / R-09: description-matched results ---
+
+    #[test]
+    fn description_only_match_surfaces_the_item() {
+        // Regression test for R-09: before this fix, items whose match
+        // lived in `description` but not `name` were silently filtered
+        // out. A user typing "mail" wouldn't find "Thunderbird" even
+        // though its description says "Email client".
+        let engine = SearchEngine::new();
+        let items = vec![item_with_description("Thunderbird", "Email client")];
+
+        let results = engine.search("email", items);
+
+        assert_eq!(results.len(), 1, "description-only match must surface the item");
+        assert_eq!(results[0].name, "Thunderbird");
+    }
+
+    #[test]
+    fn name_match_ranks_above_description_only_match_for_same_query() {
+        // Pin the penalty contract: when query matches one item's name
+        // and another item's description, the name match comes first.
+        let engine = SearchEngine::new();
+        let items = vec![
+            item_with_description("Gmail Helper", "zzz-unrelated"),
+            item_with_description("Thunderbird", "Gmail client"),
+        ];
+
+        let results = engine.search("gmail", items);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(
+            results[0].name, "Gmail Helper",
+            "name match must rank ahead of description-only match; got order: {:?}",
+            results.iter().map(|r| &r.name).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn when_both_name_and_description_match_name_score_wins() {
+        // If name matches, we pick the (unpenalized) name score, not the
+        // (penalized) description score. Otherwise items with keyword-
+        // stuffed descriptions could overtake their own name match.
+        let engine = SearchEngine::new();
+        let items = vec![item_with_description("Chrome", "Chrome browser from Google")];
+
+        let results = engine.search("chrome", items);
+        assert_eq!(results.len(), 1);
+
+        // The score recorded on the result should equal the name match,
+        // not the penalized description match.
+        let name_only = SearchEngine::new().score("chrome", "Chrome").unwrap();
+        assert_eq!(
+            results[0].score, name_only,
+            "when name matches, recorded score should be the name score"
+        );
+    }
+
+    #[test]
+    fn neither_name_nor_description_match_filters_the_item() {
+        // Belt-and-suspenders regression: adding description matching
+        // must not accidentally let non-matching items through.
+        let engine = SearchEngine::new();
+        let items = vec![item_with_description("Calculator", "arithmetic tool")];
+        let results = engine.search("firefox", items);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn description_match_with_empty_description_does_not_panic() {
+        // Items can legitimately have empty descriptions (clipboard
+        // entries, some note types). Must not panic or score them
+        // positively by accident.
+        let engine = SearchEngine::new();
+        let items = vec![item_with_description("Thing", "")];
+        let results = engine.search("xyz", items);
+        assert!(results.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
`SearchEngine::search` used to filter items by name-match before ranking, silently dropping any item whose match lived only in the description. Now both fields are scored; the higher of the two is kept, with a 50% penalty on description-only hits so name matches still win on cross-item ties.

Closes #10. Fixes R-09.

## Before vs after
| Query | Item | Before | After |
|---|---|---|---|
| `email` | name: **Thunderbird**, desc: Email client | filtered out | ranked via desc score |
| `gmail` | A: **Gmail Helper** (name match) + B: **Thunderbird** (desc: Gmail client) | only A | A ahead of B |
| `chrome` | name: **Chrome**, desc: Chrome browser from Google | name score | name score (description can't overtake own name) |

## Test plan
- [x] `cargo test` — 176 passed, 0 failed, 1 ignored
- [x] `npm test` — 21 passed
- [x] 5 new tests:
  - `description_only_match_surfaces_the_item`
  - `name_match_ranks_above_description_only_match_for_same_query`
  - `when_both_name_and_description_match_name_score_wins`
  - `neither_name_nor_description_match_filters_the_item`
  - `description_match_with_empty_description_does_not_panic`
- [x] Widened the test fixture's default description to a non-word so existing tests assert on name matching alone (defensive — description branch can't accidentally lift a regression)
- [ ] Manual: open Watson, type part of an app's description (e.g., "email" vs Thunderbird); verify result appears

## Notes
- Per-keystroke cost roughly doubles (two fuzzy-match calls instead of one). Skim is microsecond-per-item; at 100 items this is ~100→200μs total. Still sub-ms. If we ever outgrow it, the fix is to score `format!("{name} {description}")` once with a ranking bonus for name-prefix — not today.
- The 50% penalty constant isn't load-bearing; any value <100% preserves the "name wins on ties" contract. Tunable later behind a setting if users want pure unified ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)