### PR TITLE
WAT-206: schema_version with forward-compat migration framework

### DIFF
--- a/src-tauri/src/config/migrations.rs
+++ b/src-tauri/src/config/migrations.rs
@@ -1,0 +1,93 @@
+//! WAT-206: forward-compatible settings migrations.
+//!
+//! Config files carry a `schema_version` field. When a file has a lower
+//! version than the current binary, the migrations in this module run in
+//! order to bring it up to date. Each migration mutates `Settings` in
+//! place and bumps `schema_version` — no separate "migrator" type is
+//! needed because the data structure is small and migrations are rare.
+//!
+//! ## Adding a migration
+//!
+//! 1. Bump `CURRENT_SCHEMA_VERSION` in `config/mod.rs`.
+//! 2. Add a branch below that runs if `settings.schema_version < N` where
+//!    N is your target version. Do your mutation, then set
+//!    `settings.schema_version = N`.
+//! 3. Add a test that seeds a v(N-1) struct, runs `migrate`, and asserts
+//!    the v(N) shape.
+//!
+//! The `migrate` function is idempotent: calling it on an already-current
+//! `Settings` is a no-op.
+
+use super::settings::Settings;
+use super::CURRENT_SCHEMA_VERSION;
+
+/// Bring `settings` up to the current schema version. Safe to call on any
+/// `Settings` value — including one whose `schema_version` is already
+/// `CURRENT_SCHEMA_VERSION` (no-op) or one written by a newer Watson (no-op;
+/// the caller should have already rejected those via the schema check).
+pub fn migrate(settings: &mut Settings) {
+    // v0 → v1: the field didn't exist before WAT-206, so serde defaults
+    // it to 0. There's no actual data transformation — the v1 layout is
+    // identical to the last pre-WAT-206 layout. Bumping the version
+    // simply marks the file as "known current".
+    if settings.schema_version < 1 {
+        settings.schema_version = 1;
+    }
+
+    // Future migrations insert here:
+    //
+    // if settings.schema_version < 2 {
+    //     // ... rename a field, split a struct, etc.
+    //     settings.schema_version = 2;
+    // }
+
+    // Belt-and-suspenders: pin to current even if somehow a version in
+    // between the branches was skipped. Guarantees the caller can rely on
+    // `settings.schema_version == CURRENT_SCHEMA_VERSION` after migrate.
+    if settings.schema_version < CURRENT_SCHEMA_VERSION {
+        settings.schema_version = CURRENT_SCHEMA_VERSION;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migrate_bumps_v0_to_current() {
+        let mut settings = Settings::default();
+        settings.schema_version = 0;
+        migrate(&mut settings);
+        assert_eq!(settings.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn migrate_is_noop_on_current_version() {
+        let mut settings = Settings::default();
+        let before = settings.clone();
+        migrate(&mut settings);
+        // Byte-for-byte equality through the TOML round-trip is the
+        // strongest "no-op" assertion we can make without implementing
+        // PartialEq on Settings.
+        let a = toml::to_string(&before).unwrap();
+        let b = toml::to_string(&settings).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn migrate_does_not_downgrade_a_newer_file() {
+        // If a config arrived with a version newer than we understand, we
+        // should NOT attempt to "migrate" it downward. The caller is
+        // expected to reject the file before calling migrate, but be
+        // defensive: if they didn't, we must not silently rewrite the
+        // version.
+        let mut settings = Settings::default();
+        settings.schema_version = CURRENT_SCHEMA_VERSION + 5;
+        migrate(&mut settings);
+        assert_eq!(
+            settings.schema_version,
+            CURRENT_SCHEMA_VERSION + 5,
+            "migrate must not overwrite a higher version"
+        );
+    }
+}

--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -1,9 +1,31 @@
+pub mod migrations;
 pub mod settings;
 
 use std::fs;
 use std::path::{Path, PathBuf};
 use directories::ProjectDirs;
 use crate::config::settings::Settings;
+
+/// WAT-206: highest settings schema version this binary knows how to load.
+/// A config file with a higher version is rejected and the app falls back
+/// to defaults with a startup warning — we don't know what fields mean in
+/// the future, so pretending to load them would silently drop data.
+/// Bump this when adding a migration in `config/migrations.rs`.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+
+/// Non-fatal conditions the caller of `load_*_with_warnings` should surface
+/// to the UI. Intentionally free of Tauri / frontend types so `config` can
+/// stay a leaf module; the caller translates into `warnings::StartupWarning`.
+#[derive(Debug, Clone)]
+pub enum SettingsWarning {
+    /// The on-disk config was written by a Watson newer than this binary.
+    /// We're running with defaults; the user's real config is untouched on
+    /// disk and they'll get it back when they upgrade again.
+    FromNewerVersion {
+        file_version: u32,
+        supported_version: u32,
+    },
+}
 
 pub fn get_config_dir() -> Option<PathBuf> {
     ProjectDirs::from("com", "watson", "Watson")
@@ -23,23 +45,49 @@ pub fn get_config_path() -> Option<PathBuf> {
 /// which swallowed the error silently; users had no signal that their edit
 /// didn't take. This function surfaces the error on stderr until WAT-406
 /// (notifications drawer) can render it in-app.
-pub fn parse_settings(content: &str) -> Settings {
-    match toml::from_str::<Settings>(content) {
-        Ok(settings) => settings,
+///
+/// WAT-206: also enforces the schema version. A file newer than
+/// `CURRENT_SCHEMA_VERSION` is rejected (defaults + `FromNewerVersion`
+/// warning); an older file is migrated forward via `migrations::migrate`.
+pub fn parse_settings(content: &str) -> (Settings, Option<SettingsWarning>) {
+    let mut settings = match toml::from_str::<Settings>(content) {
+        Ok(s) => s,
         Err(e) => {
             eprintln!(
                 "watson: failed to parse config.toml ({e}); falling back to default settings"
             );
-            Settings::default()
+            return (Settings::default(), None);
         }
+    };
+
+    // WAT-206: newer-version gate. Defensive — we can't read fields we
+    // don't know about, and we don't want to silently overwrite them on
+    // the next save. Fall back to defaults in memory; leave disk intact.
+    if settings.schema_version > CURRENT_SCHEMA_VERSION {
+        eprintln!(
+            "watson: config.toml was written by a newer Watson (schema v{}); this binary \
+             supports up to v{}. Running with defaults; your config is preserved on disk.",
+            settings.schema_version, CURRENT_SCHEMA_VERSION
+        );
+        return (
+            Settings::default(),
+            Some(SettingsWarning::FromNewerVersion {
+                file_version: settings.schema_version,
+                supported_version: CURRENT_SCHEMA_VERSION,
+            }),
+        );
     }
+
+    // Older or equal: migrate forward (no-op when already current).
+    migrations::migrate(&mut settings);
+    (settings, None)
 }
 
 /// Load settings from an explicit path. Returns `Settings::default()` if the
 /// file is missing or unreadable. Used by tests and by `load_settings()`.
-pub fn load_settings_from(path: &Path) -> Settings {
+pub fn load_settings_from(path: &Path) -> (Settings, Option<SettingsWarning>) {
     if !path.exists() {
-        return Settings::default();
+        return (Settings::default(), None);
     }
     match fs::read_to_string(path) {
         Ok(content) => parse_settings(&content),
@@ -48,22 +96,22 @@ pub fn load_settings_from(path: &Path) -> Settings {
                 "watson: failed to read config at {}: {e}; falling back to default settings",
                 path.display()
             );
-            Settings::default()
+            (Settings::default(), None)
         }
     }
 }
 
-pub fn load_settings() -> Settings {
+pub fn load_settings() -> (Settings, Option<SettingsWarning>) {
     let path = match get_config_path() {
         Some(p) => p,
-        None => return Settings::default(),
+        None => return (Settings::default(), None),
     };
 
     if !path.exists() {
         // First run: persist defaults so the user has something to edit.
         let settings = Settings::default();
         let _ = save_settings(&settings);
-        return settings;
+        return (settings, None);
     }
 
     load_settings_from(&path)

--- a/src-tauri/src/config/settings.rs
+++ b/src-tauri/src/config/settings.rs
@@ -2,6 +2,15 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
+    /// WAT-206: schema version of the config file. A config with a version
+    /// higher than `CURRENT_SCHEMA_VERSION` was written by a newer Watson
+    /// and we refuse to load it (fall back to defaults + surface a startup
+    /// warning) rather than silently dropping fields we don't understand.
+    /// Missing field (old configs written before WAT-206) defaults to 0,
+    /// which `config::migrations::migrate` then bumps to the current
+    /// version.
+    #[serde(default)]
+    pub schema_version: u32,
     pub general: GeneralSettings,
     pub activation: ActivationSettings,
     pub search: SearchSettings,
@@ -128,6 +137,7 @@ fn default_accent() -> String { "system".to_string() }
 impl Default for Settings {
     fn default() -> Self {
         Settings {
+            schema_version: crate::config::CURRENT_SCHEMA_VERSION,
             general: GeneralSettings {
                 launch_at_login: true,
                 show_in_dock: false,

--- a/src-tauri/src/config/tests.rs
+++ b/src-tauri/src/config/tests.rs
@@ -1,9 +1,30 @@
 #[cfg(test)]
 mod tests {
-    use crate::config::{load_settings_from, parse_settings};
+    use crate::config::{load_settings_from, parse_settings, SettingsWarning, CURRENT_SCHEMA_VERSION};
     use crate::config::settings::Settings;
     use std::collections::HashSet;
     use tempfile::TempDir;
+
+    /// Helper: strip the warning channel for tests that only care about the
+    /// returned `Settings`. Panics if an unexpected warning surfaces so the
+    /// caller notices a behavior change instead of silently missing it.
+    fn parse_ok(content: &str) -> Settings {
+        let (settings, warning) = parse_settings(content);
+        assert!(
+            warning.is_none(),
+            "parse_settings unexpectedly emitted a warning: {warning:?}"
+        );
+        settings
+    }
+
+    fn load_from_ok(path: &std::path::Path) -> Settings {
+        let (settings, warning) = load_settings_from(path);
+        assert!(
+            warning.is_none(),
+            "load_settings_from unexpectedly emitted a warning: {warning:?}"
+        );
+        settings
+    }
 
     /// Prefixes reserved by the search dispatcher in `lib.rs::search`.
     /// A web-search keyword colliding with one of these silently shadows
@@ -79,7 +100,7 @@ mod tests {
         // An empty file fails to satisfy any required struct field; must not
         // panic. The `activation.hotkey` assertion proves we landed on
         // `Settings::default()` rather than some partially-populated state.
-        let settings = parse_settings("");
+        let settings = parse_ok("");
         assert_eq!(settings.activation.hotkey, "Alt+Space");
     }
 
@@ -95,7 +116,7 @@ max_results = 8
 web_searches = [
   { name = "Google", keyword = "g", url = "https://www.google.com/search?q={query}"
 "#;
-        let settings = parse_settings(broken);
+        let settings = parse_ok(broken);
         // Full fallback: every default value is present, nothing from the
         // partial input leaked through.
         assert_eq!(settings.search.max_results, 8);
@@ -117,7 +138,7 @@ web_searches = [
 hotkey = "Alt+Space"
 show_tray_icon = true
 "#;
-        let settings = parse_settings(partial);
+        let settings = parse_ok(partial);
         // If parse had succeeded, hotkey from the file would survive and
         // launch_at_login would come from serde default. Since it fails, we
         // get full defaults — both values come from Settings::default().
@@ -146,7 +167,7 @@ fuzzy_match_threshold = 0.6
 mode = "system"
 accent_color = "system"
 "#;
-        let settings = parse_settings(bad_type);
+        let settings = parse_ok(bad_type);
         assert_eq!(settings.search.max_results, 8);
     }
 
@@ -175,7 +196,7 @@ fuzzy_match_threshold = 0.6
 mode = "dark"
 accent_color = "blue"
 "#;
-        let settings = parse_settings(with_extra);
+        let settings = parse_ok(with_extra);
         // Real values from the file survive; no fallback triggered.
         assert_eq!(settings.search.max_results, 12);
         assert_eq!(settings.theme.mode, "dark");
@@ -189,7 +210,7 @@ accent_color = "blue"
         // fallback path.
         let defaults = Settings::default();
         let serialized = toml::to_string_pretty(&defaults).expect("serialize defaults");
-        let parsed = parse_settings(&serialized);
+        let parsed = parse_ok(&serialized);
         assert_eq!(parsed.search.max_results, defaults.search.max_results);
         assert_eq!(parsed.activation.hotkey, defaults.activation.hotkey);
         assert_eq!(parsed.web_searches.len(), defaults.web_searches.len());
@@ -199,7 +220,7 @@ accent_color = "blue"
     fn load_settings_from_returns_defaults_for_missing_file() {
         let dir = TempDir::new().unwrap();
         let missing = dir.path().join("never-created.toml");
-        let settings = load_settings_from(&missing);
+        let settings = load_from_ok(&missing);
         assert_eq!(settings.activation.hotkey, "Alt+Space");
     }
 
@@ -210,7 +231,7 @@ accent_color = "blue"
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("config.toml");
         std::fs::write(&path, "this is not valid toml = [").unwrap();
-        let settings = load_settings_from(&path);
+        let settings = load_from_ok(&path);
         assert_eq!(settings.activation.hotkey, "Alt+Space");
     }
 
@@ -225,7 +246,150 @@ accent_color = "blue"
         let content = toml::to_string_pretty(&settings).unwrap();
         std::fs::write(&path, content).unwrap();
 
-        let loaded = load_settings_from(&path);
+        let loaded = load_from_ok(&path);
         assert_eq!(loaded.search.max_results, 42);
+    }
+
+    // --- WAT-206: schema_version + migrations ---
+
+    #[test]
+    fn default_settings_carry_current_schema_version() {
+        // First-run config is tagged with the current version so a later
+        // downgrade sees a known marker (not a missing field).
+        let settings = Settings::default();
+        assert_eq!(settings.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn default_settings_serialize_schema_version() {
+        // Serialized form must emit the field — otherwise a user could
+        // round-trip through an external editor and lose the version tag.
+        let toml_str = toml::to_string_pretty(&Settings::default()).unwrap();
+        assert!(
+            toml_str.contains("schema_version"),
+            "serialized default must include schema_version; got:\n{toml_str}"
+        );
+    }
+
+    #[test]
+    fn config_missing_schema_version_is_treated_as_v0_and_migrated() {
+        // Configs written before WAT-206 have no schema_version field.
+        // serde defaults them to 0; the migrator bumps to CURRENT without
+        // emitting a warning (this is the upgrade path, not the rejection
+        // path).
+        let old_style = r#"
+[general]
+launch_at_login = true
+
+[activation]
+hotkey = "Alt+Space"
+show_tray_icon = true
+
+[search]
+max_results = 8
+show_recently_used = true
+fuzzy_match_threshold = 0.6
+
+[theme]
+mode = "system"
+accent_color = "system"
+"#;
+        let (settings, warning) = parse_settings(old_style);
+        assert!(warning.is_none(), "v0 migration should be silent");
+        assert_eq!(settings.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn config_with_current_version_is_loaded_as_is() {
+        let defaults = Settings::default();
+        let toml_str = toml::to_string_pretty(&defaults).unwrap();
+        let (settings, warning) = parse_settings(&toml_str);
+        assert!(warning.is_none());
+        assert_eq!(settings.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn config_with_newer_version_is_rejected_with_warning_and_defaults() {
+        // The AC from WAT-206: a file written by a newer Watson must NOT
+        // silently load with defaults filling in the fields we don't know.
+        // It should fall back AND surface the mismatch so the user knows.
+        let future_cfg = format!(
+            r#"
+schema_version = {}
+
+[general]
+launch_at_login = false
+
+[activation]
+hotkey = "Ctrl+Space"
+show_tray_icon = false
+
+[search]
+max_results = 99
+show_recently_used = false
+fuzzy_match_threshold = 0.9
+
+[theme]
+mode = "dark"
+accent_color = "red"
+"#,
+            CURRENT_SCHEMA_VERSION + 1
+        );
+        let (settings, warning) = parse_settings(&future_cfg);
+
+        match warning {
+            Some(SettingsWarning::FromNewerVersion {
+                file_version,
+                supported_version,
+            }) => {
+                assert_eq!(file_version, CURRENT_SCHEMA_VERSION + 1);
+                assert_eq!(supported_version, CURRENT_SCHEMA_VERSION);
+            }
+            other => panic!("expected FromNewerVersion warning, got {other:?}"),
+        }
+
+        // Crucially, the returned settings are defaults — none of the
+        // user's newer-config values leaked through. This is the
+        // silent-data-loss regression the ticket guards against.
+        assert_eq!(settings.search.max_results, 8);
+        assert_eq!(settings.activation.hotkey, "Alt+Space");
+        assert_eq!(settings.theme.mode, "system");
+    }
+
+    #[test]
+    fn load_settings_from_propagates_newer_version_warning() {
+        // End-to-end: a real file on disk with schema_version = CURRENT+1
+        // surfaces the warning through the disk-read path, not just the
+        // string-parse path.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        let content = format!(
+            r#"schema_version = {}
+
+[general]
+launch_at_login = true
+
+[activation]
+hotkey = "Alt+Space"
+show_tray_icon = true
+
+[search]
+max_results = 8
+show_recently_used = true
+fuzzy_match_threshold = 0.6
+
+[theme]
+mode = "system"
+accent_color = "system"
+"#,
+            CURRENT_SCHEMA_VERSION + 1
+        );
+        std::fs::write(&path, content).unwrap();
+
+        let (_settings, warning) = load_settings_from(&path);
+        assert!(
+            matches!(warning, Some(SettingsWarning::FromNewerVersion { .. })),
+            "newer-version warning should propagate through load_settings_from"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -388,6 +388,15 @@ fn dismiss_startup_warning(id: String, state: State<AppState>) -> bool {
     state.startup_warnings.dismiss(&id)
 }
 
+/// WAT-206: open the OS file browser at the config directory. Action
+/// target for the "Open config folder" button on the settings-schema
+/// warning banner.
+#[tauri::command]
+fn open_config_folder() -> Result<(), String> {
+    let dir = config::get_config_dir().ok_or("Could not determine config directory")?;
+    open::that(&dir).map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let db = Arc::new(Database::new().expect("Failed to initialize database"));
@@ -398,7 +407,7 @@ pub fn run() {
         .map(|dirs| dirs.data_dir().join("notes"))
         .unwrap_or_else(|| std::path::PathBuf::from("./notes"));
     let notes = NotesManager::new(Arc::clone(&db), notes_path);
-    let settings = config::load_settings();
+    let (settings, settings_warning) = config::load_settings();
     let indexer = get_indexer();
     let indexed_apps = indexer.index_apps();
 
@@ -408,6 +417,18 @@ pub fn run() {
 
     // Initialize file search manager
     let file_search = Arc::new(FileSearchManager::new(Arc::clone(&db)));
+
+    // WAT-206: settings warnings surface via the same banner infrastructure
+    // as WAT-105's shortcut failures. Build the container up-front so we
+    // can push before handing it off to `manage()`.
+    let startup_warnings = StartupWarnings::new();
+    if let Some(config::SettingsWarning::FromNewerVersion {
+        file_version,
+        supported_version,
+    }) = settings_warning
+    {
+        startup_warnings.record_settings_from_newer_version(file_version, supported_version);
+    }
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -423,7 +444,7 @@ pub fn run() {
             scratchpad,
             notes,
             file_search,
-            startup_warnings: StartupWarnings::new(),
+            startup_warnings,
         })
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
@@ -513,7 +534,8 @@ pub fn run() {
             cancel_reindex_files,
             clear_file_index,
             get_startup_warnings,
-            dismiss_startup_warning
+            dismiss_startup_warning,
+            open_config_folder
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/warnings.rs
+++ b/src-tauri/src/warnings.rs
@@ -24,6 +24,10 @@ pub enum StartupWarningKind {
     /// already taken by another app (common on some Linux WMs, macOS
     /// system preferences, Windows apps that bind Alt+Space).
     ShortcutUnavailable,
+    /// WAT-206: config.toml was written by a Watson newer than this binary.
+    /// We're running with defaults; the user's real config is untouched
+    /// on disk and they'll get it back when they upgrade again.
+    SettingsFromNewerVersion,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -65,6 +69,27 @@ impl StartupWarnings {
         let before = inner.len();
         inner.retain(|w| w.id != id);
         inner.len() != before
+    }
+
+    /// WAT-206: record that the on-disk config was written by a newer
+    /// Watson. Uses a fixed id so the banner deduplicates if somehow the
+    /// helper is invoked more than once per startup.
+    pub fn record_settings_from_newer_version(
+        &self,
+        file_version: u32,
+        supported_version: u32,
+    ) {
+        let id = "settings-from-newer-version".to_string();
+        let _ = self.dismiss(&id);
+        self.push(StartupWarning {
+            id,
+            kind: StartupWarningKind::SettingsFromNewerVersion,
+            message: format!(
+                "Your config.toml was written by a newer Watson (schema v{file_version}); \
+                 this version supports up to v{supported_version}. Running with defaults. \
+                 Your config is preserved on disk — upgrade Watson to use it again."
+            ),
+        });
     }
 
     /// Convenience constructor for the common case: the global hotkey
@@ -179,5 +204,26 @@ mod tests {
         w.record_shortcut_unavailable("Alt+Space", "");
         assert!(w.dismiss("shortcut-unavailable:Alt+Space"));
         assert!(w.list().is_empty());
+    }
+
+    // --- WAT-206: settings schema-version warning ---
+
+    #[test]
+    fn record_settings_from_newer_version_mentions_both_versions() {
+        let w = StartupWarnings::new();
+        w.record_settings_from_newer_version(2, 1);
+        let warning = &w.list()[0];
+        assert_eq!(warning.kind, StartupWarningKind::SettingsFromNewerVersion);
+        assert!(warning.message.contains("v2"));
+        assert!(warning.message.contains("v1"));
+    }
+
+    #[test]
+    fn record_settings_from_newer_version_is_idempotent() {
+        // Shouldn't stack duplicate banners if invoked twice per startup.
+        let w = StartupWarnings::new();
+        w.record_settings_from_newer_version(2, 1);
+        w.record_settings_from_newer_version(2, 1);
+        assert_eq!(w.list().len(), 1);
     }
 }

--- a/src/components/StartupWarningBanner.tsx
+++ b/src/components/StartupWarningBanner.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { useAppStore } from '../stores/app';
 import type { StartupWarning } from '../types';
 
@@ -53,7 +54,6 @@ function WarningRow({
   onDismiss: () => void;
   onOpenSettings: () => void;
 }) {
-  const isHotkey = warning.kind === 'shortcut_unavailable';
   return (
     <li className="flex items-start gap-2 px-4 py-2 text-xs text-amber-900 dark:text-amber-100">
       <svg
@@ -70,13 +70,31 @@ function WarningRow({
 
       <p className="flex-1 leading-snug">{warning.message}</p>
 
-      {isHotkey && (
+      {warning.kind === 'shortcut_unavailable' && (
         <button
           type="button"
           onClick={onOpenSettings}
           className="text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap"
         >
           Change hotkey
+        </button>
+      )}
+
+      {warning.kind === 'settings_from_newer_version' && (
+        <button
+          type="button"
+          onClick={() => {
+            // WAT-206: open the config dir in the OS file browser. Best-
+            // effort — surface errors to the console so users aren't
+            // left wondering why nothing happened. WAT-406 will move this
+            // to the notifications drawer.
+            invoke('open_config_folder').catch((err) =>
+              console.error('Failed to open config folder:', err),
+            );
+          }}
+          className="text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap"
+        >
+          Open config folder
         </button>
       )}
 

--- a/src/components/__tests__/StartupWarningBanner.test.tsx
+++ b/src/components/__tests__/StartupWarningBanner.test.tsx
@@ -138,4 +138,44 @@ describe('StartupWarningBanner', () => {
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveAttribute('aria-live', 'polite');
   });
+
+  // --- WAT-206 ---
+
+  it('shows "Open config folder" button for settings_from_newer_version kind', async () => {
+    const warning: StartupWarning = {
+      id: 'settings-from-newer-version',
+      kind: 'settings_from_newer_version',
+      message: 'Your config was written by a newer Watson.',
+    };
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [warning];
+      if (cmd === 'open_config_folder') return undefined;
+      return undefined;
+    });
+
+    const user = userEvent.setup();
+    render(<StartupWarningBanner onOpenSettings={() => {}} />);
+
+    const button = await screen.findByRole('button', { name: /open config folder/i });
+    await user.click(button);
+
+    expect(mockInvoke).toHaveBeenCalledWith('open_config_folder');
+  });
+
+  it('does not show "Change hotkey" for settings_from_newer_version kind', async () => {
+    const warning: StartupWarning = {
+      id: 'settings-from-newer-version',
+      kind: 'settings_from_newer_version',
+      message: 'Your config was written by a newer Watson.',
+    };
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_startup_warnings') return [warning];
+      return undefined;
+    });
+
+    render(<StartupWarningBanner onOpenSettings={() => {}} />);
+
+    await screen.findByText(warning.message);
+    expect(screen.queryByRole('button', { name: /change hotkey/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface FileSearchSettings {
   max_depth: number;
 }
 
-export type StartupWarningKind = 'shortcut_unavailable';
+export type StartupWarningKind = 'shortcut_unavailable' | 'settings_from_newer_version';
 
 export interface StartupWarning {
   id: string;


### PR DESCRIPTION
## Summary
- `schema_version: u32` on `Settings`, serialized always; `CURRENT_SCHEMA_VERSION = 1`.
- Newer-than-supported configs fall back to defaults + surface a startup warning (reuses WAT-105 banner).
- New `open_config_folder` Tauri command; banner shows "Open config folder" for the new warning kind.
- `config/migrations.rs` — empty starter registry with a template for future migrations and a no-op v0 → v1 bump so pre-WAT-206 configs upgrade cleanly.

Closes #14.

## Why
Before this PR, `config.toml` had no version tag. A binary upgrade could silently add fields (handled fine by serde defaults) but a downgrade would rewrite the file and drop anything the older binary didn't know about. Now we have a rejection path that preserves user data on disk.

## API change
`parse_settings` and `load_settings_from` now return `(Settings, Option<SettingsWarning>)`. All existing call sites updated. Tests use `parse_ok` / `load_from_ok` helpers that assert no warning emerged — future regressions land loudly on the "happy path".

## Test plan
- [x] `cargo test` — 187 passed (was 176; +11 new)
- [x] `npm test` — 23 passed (was 21; +2 new)
- [x] `npm run build` — clean
- [ ] Manual: hand-edit config.toml to `schema_version = 999`, launch Watson, verify banner appears with "Open config folder" — clicking opens the config dir in Finder/Explorer.

## Follow-ups (not this PR)
- First real migration will land when we add the first breaking-change setting.
- WAT-406 (notifications drawer) migrates these banners into a drawer; contract stays the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)