### PR TITLE
WAT-205: Warn when web-search keyword shadows a reserved prefix

### DIFF
--- a/src-tauri/src/config/mod.rs
+++ b/src-tauri/src/config/mod.rs
@@ -13,6 +13,30 @@ use crate::config::settings::Settings;
 /// Bump this when adding a migration in `config/migrations.rs`.
 pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 
+/// WAT-205 / R-10: query prefixes that shadow user-defined web-search
+/// keywords if reused.
+///
+/// The list is a superset of `search::dispatch::RESERVED_PREFIXES`
+/// (router-level reserved prefixes — notes / files / clipboard) plus
+/// the UI-level prefixes that the SearchBar or downstream dispatchers
+/// interpret specially: `s` (scratchpad chained shortcut), `>` (system
+/// command prefix). A web-search keyword equal to any of these is
+/// effectively unreachable, so the settings UI warns the user.
+///
+/// Returns a `Vec` rather than a `&[&str]` so it can be serialized
+/// directly by the Tauri command bridge.
+pub fn user_reserved_prefixes() -> Vec<&'static str> {
+    let mut out: Vec<&'static str> = crate::search::dispatch::RESERVED_PREFIXES.to_vec();
+    // UI-level reserved. Kept in sync manually with:
+    // - `SearchBar.tsx` empty-query keyboard shortcuts (s, `, n, N, f)
+    // - `lib.rs::search` command-prefix detection (>).
+    // `n`, `f`, and `cb` are already in the router list above.
+    // The backtick `` ` `` is a keyboard char only, not a query prefix,
+    // so it's omitted here.
+    out.extend(["s", ">"]);
+    out
+}
+
 /// Non-fatal conditions the caller of `load_*_with_warnings` should surface
 /// to the UI. Intentionally free of Tauri / frontend types so `config` can
 /// stay a leaf module; the caller translates into `warnings::StartupWarning`.

--- a/src-tauri/src/config/tests.rs
+++ b/src-tauri/src/config/tests.rs
@@ -1,6 +1,9 @@
 #[cfg(test)]
 mod tests {
-    use crate::config::{load_settings_from, parse_settings, SettingsWarning, CURRENT_SCHEMA_VERSION};
+    use crate::config::{
+        load_settings_from, parse_settings, user_reserved_prefixes, SettingsWarning,
+        CURRENT_SCHEMA_VERSION,
+    };
     use crate::config::settings::Settings;
     use std::collections::HashSet;
     use tempfile::TempDir;
@@ -30,6 +33,11 @@ mod tests {
     /// A web-search keyword colliding with one of these silently shadows
     /// the reserved feature (notes / files / clipboard / scratchpad /
     /// system commands) and is effectively unreachable.
+    ///
+    /// WAT-205: the canonical list now lives in `user_reserved_prefixes()`.
+    /// This local constant is pinned via
+    /// `local_reserved_prefixes_fixture_matches_canonical` below, so any
+    /// drift between the two is caught.
     const RESERVED_PREFIXES: &[&str] =
         &["n", "notes", "f", "files", "cb", "clip", "s", ">"];
 
@@ -354,6 +362,48 @@ accent_color = "red"
         assert_eq!(settings.search.max_results, 8);
         assert_eq!(settings.activation.hotkey, "Alt+Space");
         assert_eq!(settings.theme.mode, "system");
+    }
+
+    // --- WAT-205: user-reserved prefix list ---
+
+    #[test]
+    fn user_reserved_prefixes_is_superset_of_router_reserved_prefixes() {
+        // Single source of truth contract: the UX-level reserved list must
+        // include every router-level reserved prefix. If `dispatch.rs` adds
+        // a new reserved prefix in the future, this test fails until
+        // `user_reserved_prefixes` is extended to match.
+        let user: HashSet<&'static str> = user_reserved_prefixes().into_iter().collect();
+        for router_prefix in crate::search::dispatch::RESERVED_PREFIXES {
+            assert!(
+                user.contains(router_prefix),
+                "user_reserved_prefixes missing router-reserved prefix '{router_prefix}' \
+                 (present: {user:?})",
+            );
+        }
+    }
+
+    #[test]
+    fn user_reserved_prefixes_includes_ui_level_reserved() {
+        // Pin the UX-only additions ('s' scratchpad shortcut, '>' system-
+        // command prefix). If either is removed intentionally, update this
+        // test and the SearchBar/dispatch call sites together.
+        let user: HashSet<&'static str> = user_reserved_prefixes().into_iter().collect();
+        assert!(user.contains("s"), "UI-level 's' (scratchpad) must be reserved");
+        assert!(user.contains(">"), "UI-level '>' (system commands) must be reserved");
+    }
+
+    #[test]
+    fn local_reserved_prefixes_fixture_matches_canonical() {
+        // The local `RESERVED_PREFIXES` fixture in this test module used to
+        // be a hand-maintained copy. Now it's a pin: if the canonical list
+        // drifts, the fixture drifts, and this test catches it before the
+        // other web-search-keyword tests silently pass on stale data.
+        let canonical: HashSet<&'static str> = user_reserved_prefixes().into_iter().collect();
+        let local: HashSet<&'static str> = RESERVED_PREFIXES.iter().copied().collect();
+        assert_eq!(
+            canonical, local,
+            "local fixture has drifted from user_reserved_prefixes()"
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -397,6 +397,13 @@ fn open_config_folder() -> Result<(), String> {
     open::that(&dir).map_err(|e| e.to_string())
 }
 
+/// WAT-205: returns the list of query prefixes the settings UI should flag
+/// as unreachable if reused as a web-search keyword.
+#[tauri::command]
+fn get_reserved_prefixes() -> Vec<&'static str> {
+    config::user_reserved_prefixes()
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let db = Arc::new(Database::new().expect("Failed to initialize database"));
@@ -535,7 +542,8 @@ pub fn run() {
             clear_file_index,
             get_startup_warnings,
             dismiss_startup_warning,
-            open_config_folder
+            open_config_folder,
+            get_reserved_prefixes
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,12 +45,14 @@ function WebSearchEditor({
   search,
   onSave,
   onCancel,
-  onDelete
+  onDelete,
+  reservedPrefixes,
 }: {
   search: WebSearch | null;
   onSave: (ws: WebSearch) => void;
   onCancel: () => void;
   onDelete?: () => void;
+  reservedPrefixes: string[];
 }) {
   const [name, setName] = useState(search?.name || '');
   const [keyword, setKeyword] = useState(search?.keyword || '');
@@ -59,6 +61,9 @@ function WebSearchEditor({
 
   // Check if URL template uses {instance} placeholder
   const needsInstance = url.includes('{instance}');
+  // WAT-205: don't block save on a collision — the user may be intentionally
+  // testing or may have a reason to keep the row. Just surface the issue.
+  const isReservedKeyword = reservedPrefixes.includes(keyword);
   const isValid = name && keyword && url && (!needsInstance || instance);
 
   const handleSave = () => {
@@ -93,6 +98,17 @@ function WebSearchEditor({
           placeholder="g"
           className="w-full px-3 py-1.5 text-sm bg-[var(--background)] border border-[var(--border)] rounded-lg outline-none focus:ring-1 focus:ring-blue-500"
         />
+        {isReservedKeyword && (
+          <p
+            role="alert"
+            className="text-xs text-amber-600 dark:text-amber-400 mt-1"
+          >
+            "{keyword}" is a reserved query prefix — this web search will
+            be unreachable because the prefix always triggers a built-in
+            action. Pick a different keyword or save anyway if that's
+            intended.
+          </p>
+        )}
       </div>
       <div>
         <label className="text-xs text-gray-500 mb-1 block">URL (use {'{query}'} for search term, {'{instance}'} for subdomain)</label>
@@ -149,7 +165,7 @@ function WebSearchEditor({
 }
 
 function SettingsPanel({ onClose }: { onClose: () => void }) {
-  const { settings, saveSettings, reindexApps, reindexFiles } = useAppStore();
+  const { settings, saveSettings, reindexApps, reindexFiles, reservedPrefixes } = useAppStore();
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [isAddingNew, setIsAddingNew] = useState(false);
   const [version, setVersion] = useState('');
@@ -260,6 +276,7 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
                 search={null}
                 onSave={(ws) => handleSaveWebSearch(ws)}
                 onCancel={() => setIsAddingNew(false)}
+                reservedPrefixes={reservedPrefixes}
               />
             )}
 
@@ -271,6 +288,7 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
                     onSave={(updated) => handleSaveWebSearch(updated, index)}
                     onCancel={() => setEditingIndex(null)}
                     onDelete={() => handleDeleteWebSearch(index)}
+                    reservedPrefixes={reservedPrefixes}
                   />
                 ) : (
                   <div
@@ -285,6 +303,14 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
                       {ws.url.includes('{instance}') && !ws.instance && (
                         <span className="text-[10px] px-1.5 py-0.5 bg-amber-500/20 text-amber-600 dark:text-amber-400 rounded font-medium">
                           Setup needed
+                        </span>
+                      )}
+                      {reservedPrefixes.includes(ws.keyword) && (
+                        <span
+                          className="text-[10px] px-1.5 py-0.5 bg-amber-500/20 text-amber-600 dark:text-amber-400 rounded font-medium"
+                          title={`"${ws.keyword}" is a reserved query prefix — this search is unreachable.`}
+                        >
+                          Shadowed
                         </span>
                       )}
                     </div>
@@ -404,11 +430,12 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
 }
 
 function App() {
-  const { loadSettings, reindexApps, settings, showSettings, setShowSettings, resizeWindow, scratchpadVisible, noteEditorVisible } = useAppStore();
+  const { loadSettings, reindexApps, settings, showSettings, setShowSettings, resizeWindow, scratchpadVisible, noteEditorVisible, loadReservedPrefixes } = useAppStore();
 
   useEffect(() => {
     loadSettings();
     reindexApps();
+    loadReservedPrefixes();
     resizeWindow(); // Set initial window size
 
     // Disable default context menu

--- a/src/stores/__tests__/reservedPrefixes.test.ts
+++ b/src/stores/__tests__/reservedPrefixes.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { useAppStore } from '../app';
+
+const mockInvoke = vi.mocked(invoke);
+
+function resetStore() {
+  useAppStore.setState({
+    query: '',
+    results: [],
+    selectedIndex: 0,
+    settings: null,
+    isLoading: false,
+    showSettings: false,
+    scratchpad: '',
+    scratchpadVisible: false,
+    currentNote: null,
+    noteEditorVisible: false,
+    startupWarnings: [],
+    reservedPrefixes: [],
+  });
+}
+
+describe('store.loadReservedPrefixes (WAT-205)', () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockReset();
+  });
+
+  it('is empty before load so the UI can render without a populated list', () => {
+    expect(useAppStore.getState().reservedPrefixes).toEqual([]);
+  });
+
+  it('populates reservedPrefixes from the backend get_reserved_prefixes command', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_reserved_prefixes') return ['n', 'notes', 'f', 'files', 'cb', 'clip', 's', '>'];
+      return undefined;
+    });
+
+    await useAppStore.getState().loadReservedPrefixes();
+
+    const state = useAppStore.getState();
+    expect(state.reservedPrefixes).toContain('n');
+    expect(state.reservedPrefixes).toContain('>');
+    expect(state.reservedPrefixes).toContain('s');
+    // Length check is a sanity guard — if the Rust side adds a prefix, the
+    // Vitest mock here needs updating too, and this assertion will nudge
+    // the person making the change.
+    expect(state.reservedPrefixes).toHaveLength(8);
+  });
+
+  it('leaves reservedPrefixes untouched when the backend call fails', async () => {
+    mockInvoke.mockRejectedValue(new Error('ipc failed'));
+    // Seed a known-empty starting state so we can assert no mutation.
+    useAppStore.setState({ reservedPrefixes: [] });
+
+    await useAppStore.getState().loadReservedPrefixes();
+
+    expect(useAppStore.getState().reservedPrefixes).toEqual([]);
+  });
+});

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -14,6 +14,7 @@ interface AppState {
   currentNote: Note | null;
   noteEditorVisible: boolean;
   startupWarnings: StartupWarning[];
+  reservedPrefixes: string[];
 
   setQuery: (query: string) => void;
   setSelectedIndex: (index: number) => void;
@@ -38,6 +39,7 @@ interface AppState {
   reindexFiles: () => Promise<number>;
   loadStartupWarnings: () => Promise<void>;
   dismissStartupWarning: (id: string) => Promise<void>;
+  loadReservedPrefixes: () => Promise<void>;
 }
 
 // Height constants
@@ -62,6 +64,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   currentNote: null,
   noteEditorVisible: false,
   startupWarnings: [],
+  reservedPrefixes: [],
 
   setQuery: async (query: string) => {
     set({ query, selectedIndex: 0 });
@@ -302,6 +305,15 @@ export const useAppStore = create<AppState>((set, get) => ({
       await invoke('dismiss_startup_warning', { id });
     } catch (e) {
       console.error('Failed to dismiss startup warning:', e);
+    }
+  },
+
+  loadReservedPrefixes: async () => {
+    try {
+      const prefixes = await invoke<string[]>('get_reserved_prefixes');
+      set({ reservedPrefixes: prefixes });
+    } catch (e) {
+      console.error('Failed to load reserved prefixes:', e);
     }
   },
 }));


### PR DESCRIPTION
## Summary
- New `user_reserved_prefixes()` in Rust: single source of truth, superset of `search::dispatch::RESERVED_PREFIXES`, adds UI-only prefixes (`s`, `>`).
- `get_reserved_prefixes` Tauri command + store loader (called on App mount).
- Settings UI:
  - Inline `role="alert"` warning below the keyword field in WebSearchEditor when the keyword collides.
  - "Shadowed" badge on existing web-search rows in the list.
- Does NOT block save — surfacing the hazard is the point; the user may still choose to keep the row.

Closes #13. Addresses R-10.

## Why
A user adding a web search with keyword `n` (or any reserved prefix) previously got silence: the search never fires because `classify_prefix_route` short-circuits to notes first. No error, no feedback, no hint. Now they see the problem before they commit to the setup.

## Single source of truth
The Rust test `user_reserved_prefixes_is_superset_of_router_reserved_prefixes` catches any future router-level prefix that's added to `dispatch.rs::RESERVED_PREFIXES` without being reflected in the user-facing list. The local `RESERVED_PREFIXES` fixture in `config/tests.rs` is also now pinned to the canonical function.

## Test plan
- [x] `cargo test` — 190 passed (+3: superset contract, UI-level members, fixture pin)
- [x] `npm test` — 26 passed (+3: store loader populates / handles error)
- [x] `npm run build` — clean
- [ ] Manual: Settings → Web Searches → Add → keyword `n` → inline warning appears; save; list row shows "Shadowed" badge.

## Notes
- Chose frontend-validation over save-blocking per the ticket AC: "Allow the user to save anyway if they accept the shadowing (advanced use case)". No extra prompts.
- The `isReservedKeyword` check in WebSearchEditor is a trivial `.includes()` over the backend-sourced list — kept in the render path rather than derived state because the list is ~8 items. No perf concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)