### PR TITLE
WAT-203: Inline calculator + unit/currency conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ A fast, cross-platform productivity launcher inspired by Alfred. Built with Taur
 | `cb` | Show clipboard history |
 | `cb <query>` | Search clipboard history |
 | `> <command>` | Run system command |
+| `12 * 37` | Inline arithmetic — `sqrt(144)`, `(1+2)^3`, etc. |
+| `30 C to F` | Unit conversion — temperature / length / weight |
+| `100 USD to EUR` | Currency conversion (offline, snapshotted rates) |
 
 ## Installation
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1996,6 +1996,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "meval"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79496a5651c8d57cd033c5add8ca7ee4e3d5f7587a4777484640d9cb60392d9"
+dependencies = [
+ "fnv",
+ "nom",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2110,12 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nom"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b8c256fd9471521bcb84c3cdba98921497f1a331cbc15b8030fc63b82050ce"
 
 [[package]]
 name = "num-conv"
@@ -4761,6 +4777,7 @@ dependencies = [
  "directories",
  "dirs 5.0.1",
  "fuzzy-matcher",
+ "meval",
  "open",
  "rusqlite",
  "rusqlite_migration",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ arboard = "3.4"
 chrono = { version = "0.4", features = ["serde"] }
 walkdir = "2.4"
 dirs = "5.0"
+meval = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/calculator/arithmetic.rs
+++ b/src-tauri/src/calculator/arithmetic.rs
@@ -1,0 +1,178 @@
+//! Arithmetic evaluator for WAT-203.
+//!
+//! Thin wrapper around the `meval` crate with a conservative gate that
+//! prevents false positives on ordinary search queries. The gate is
+//! strict: a query must contain at least one digit AND one "signal"
+//! character (operator, paren, or named function). A bare number alone
+//! doesn't count — `42` isn't a useful calculation, and a model number
+//! like `Galaxy S24` shouldn't be hijacked into a math context.
+
+use super::{format_number, Calculation, CalculationKind};
+
+/// Characters / tokens that indicate the query is meant as arithmetic,
+/// beyond just containing digits. Ordering reflects likelihood of use.
+const SIGNAL_CHARS: &[char] = &['+', '*', '/', '^', '%', '(', ')'];
+/// Named functions meval supports. If any of these substrings appear, the
+/// query is treated as arithmetic. These are long enough that spurious
+/// matches on ordinary English words are very unlikely (`log` is the
+/// shortest, and queries containing "log" would need an accompanying digit
+/// and typically a paren to pass meval anyway).
+const SIGNAL_FUNCTIONS: &[&str] = &[
+    "sqrt", "abs", "sin", "cos", "tan", "log", "ln", "exp", "floor", "ceil", "round",
+];
+
+/// True if the query plausibly looks like arithmetic. Cheap — runs before
+/// meval so most search queries bail early.
+fn looks_like_arithmetic(query: &str) -> bool {
+    let has_digit = query.chars().any(|c| c.is_ascii_digit());
+    if !has_digit {
+        return false;
+    }
+    if query.chars().any(|c| SIGNAL_CHARS.contains(&c)) {
+        return true;
+    }
+    SIGNAL_FUNCTIONS.iter().any(|fun| query.contains(fun))
+}
+
+pub fn detect(query: &str) -> Option<Calculation> {
+    if !looks_like_arithmetic(query) {
+        return None;
+    }
+    let value: f64 = meval::eval_str(query).ok()?;
+    // Reject non-finite results — `1/0`, `sqrt(-1)`, etc. Copy-to-clipboard
+    // of "NaN" is almost never what the user wanted; better to skip the
+    // calc and let fuzzy search handle the query.
+    if !value.is_finite() {
+        return None;
+    }
+    Some(Calculation {
+        expression: query.to_string(),
+        result: format_number(value),
+        kind: CalculationKind::Arithmetic,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(query: &str) -> String {
+        detect(query)
+            .unwrap_or_else(|| panic!("expected '{query}' to be detected as arithmetic"))
+            .result
+    }
+
+    // --- happy path ---
+
+    #[test]
+    fn simple_addition() {
+        assert_eq!(result("2+2"), "4");
+    }
+
+    #[test]
+    fn multiplication() {
+        assert_eq!(result("12*37"), "444");
+    }
+
+    #[test]
+    fn parens_and_precedence() {
+        assert_eq!(result("(1+2)*3"), "9");
+    }
+
+    #[test]
+    fn exponent() {
+        assert_eq!(result("2^10"), "1024");
+    }
+
+    #[test]
+    fn sqrt_function() {
+        assert_eq!(result("sqrt(144)"), "12");
+    }
+
+    #[test]
+    fn division_with_decimal_result() {
+        assert_eq!(result("10/4"), "2.5");
+    }
+
+    #[test]
+    fn handles_whitespace_inside_expression() {
+        assert_eq!(result("  (1 + 2) * 3  "), "9");
+    }
+
+    // --- zero false positives ---
+
+    #[test]
+    fn plain_words_without_digits_are_not_arithmetic() {
+        assert!(detect("apple").is_none());
+        assert!(detect("chrome").is_none());
+        assert!(detect("hello world").is_none());
+    }
+
+    #[test]
+    fn bare_numbers_are_not_arithmetic() {
+        // The gate requires an operator / paren / function — a single
+        // number on its own isn't a useful calculation result.
+        assert!(detect("42").is_none());
+        assert!(detect("3.14").is_none());
+        assert!(detect("-5").is_none());
+    }
+
+    #[test]
+    fn search_queries_with_incidental_digits_are_not_arithmetic() {
+        // Product-name patterns that contain digits but no operator.
+        assert!(detect("i5 cpu").is_none());
+        assert!(detect("5gb").is_none());
+        assert!(detect("3d modeling").is_none());
+        assert!(detect("iphone 15").is_none());
+        assert!(detect("Galaxy S24").is_none());
+    }
+
+    #[test]
+    fn operator_in_middle_of_words_still_gates_meval_to_reject() {
+        // "chrome - firefox" has an operator and a digit... wait, no digit.
+        // Add one.
+        // meval rejects "chrome - 1" because `chrome` isn't an identifier
+        // it knows. The gate lets it through; meval's rejection is the
+        // final stop. Ensure that chain works.
+        assert!(detect("chrome - 1").is_none());
+    }
+
+    #[test]
+    fn division_by_zero_is_not_a_result() {
+        // Non-finite → skip; user sees fuzzy search instead of "∞" copied.
+        assert!(detect("1/0").is_none());
+    }
+
+    #[test]
+    fn sqrt_of_negative_is_not_a_result() {
+        // sqrt(-1) = NaN; skip.
+        assert!(detect("sqrt(-1)").is_none());
+    }
+
+    #[test]
+    fn incomplete_expressions_are_not_detected() {
+        assert!(detect("2+").is_none());
+        assert!(detect("(1+").is_none());
+    }
+
+    #[test]
+    fn python_style_power_is_not_detected() {
+        // meval uses `^`; `**` is a syntax error. We correctly fall through.
+        assert!(detect("2**3").is_none());
+    }
+
+    // --- gate ---
+
+    #[test]
+    fn looks_like_arithmetic_requires_at_least_one_digit() {
+        assert!(!looks_like_arithmetic("a+b"));
+        assert!(!looks_like_arithmetic("sqrt(x)"));
+    }
+
+    #[test]
+    fn looks_like_arithmetic_requires_a_signal() {
+        assert!(!looks_like_arithmetic("42"));
+        assert!(looks_like_arithmetic("42+1"));
+        assert!(looks_like_arithmetic("sqrt(42)"));
+    }
+}

--- a/src-tauri/src/calculator/currency.rs
+++ b/src-tauri/src/calculator/currency.rs
@@ -1,0 +1,146 @@
+//! Currency conversion for WAT-203.
+//!
+//! Uses an offline exchange-rate table. Rates are snapshotted at build time
+//! and will drift — the result banner surfaces the snapshot date so the
+//! user knows not to trust the output for high-stakes work. A follow-up
+//! ticket can replace this with an online fetcher (cached locally, refreshed
+//! weekly) without changing the caller's contract.
+//!
+//! Pattern: `<amount> <FROM> (to|in) <TO>` where FROM and TO are 3-letter
+//! ISO codes we recognize. Case-insensitive.
+
+use super::{format_number, Calculation, CalculationKind};
+
+/// Date the `RATES` table was last snapshotted. Shown in the result so
+/// users know the age of the data. Update this when refreshing rates.
+const RATES_SNAPSHOT_DATE: &str = "2026-04-01";
+
+/// Exchange rate to 1 USD. USD is the reference; conversions are
+/// FROM → USD → TO. Rates are approximate and for display only.
+struct Rate {
+    code: &'static str,
+    per_usd: f64,
+}
+
+const RATES: &[Rate] = &[
+    Rate { code: "USD", per_usd: 1.0 },
+    Rate { code: "EUR", per_usd: 0.92 },
+    Rate { code: "GBP", per_usd: 0.79 },
+    Rate { code: "JPY", per_usd: 151.0 },
+    Rate { code: "CAD", per_usd: 1.37 },
+    Rate { code: "AUD", per_usd: 1.52 },
+    Rate { code: "CHF", per_usd: 0.91 },
+];
+
+fn lookup_rate(code: &str) -> Option<&'static Rate> {
+    let upper = code.to_ascii_uppercase();
+    RATES.iter().find(|r| r.code == upper)
+}
+
+pub fn detect(query: &str) -> Option<Calculation> {
+    let tokens: Vec<&str> = query.split_whitespace().collect();
+    if tokens.len() != 4 {
+        return None;
+    }
+    let amount: f64 = tokens[0].parse().ok()?;
+    let connector = tokens[2].to_ascii_lowercase();
+    if connector != "to" && connector != "in" {
+        return None;
+    }
+
+    let from = lookup_rate(tokens[1])?;
+    let to = lookup_rate(tokens[3])?;
+
+    // amount in USD = amount / from.per_usd
+    // amount in TO  = (amount / from.per_usd) * to.per_usd
+    let usd = amount / from.per_usd;
+    let out = usd * to.per_usd;
+
+    Some(Calculation {
+        expression: format!("{} {} to {}", format_number(amount), from.code, to.code),
+        result: format!(
+            "{} {} (rates from {})",
+            format_number(out),
+            to.code,
+            RATES_SNAPSHOT_DATE
+        ),
+        kind: CalculationKind::CurrencyConversion,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usd_to_usd_is_identity() {
+        let calc = detect("100 USD to USD").unwrap();
+        assert!(calc.result.starts_with("100 USD"), "got: {}", calc.result);
+    }
+
+    #[test]
+    fn usd_to_eur_applies_rate() {
+        let calc = detect("100 USD to EUR").unwrap();
+        assert!(
+            calc.result.starts_with("92 EUR"),
+            "expected 100 * 0.92 = 92, got: {}",
+            calc.result
+        );
+    }
+
+    #[test]
+    fn eur_to_usd_reverses_rate() {
+        let calc = detect("92 EUR to USD").unwrap();
+        // 92 / 0.92 = 100
+        assert!(calc.result.starts_with("100 USD"), "got: {}", calc.result);
+    }
+
+    #[test]
+    fn result_includes_snapshot_date() {
+        let calc = detect("10 USD to EUR").unwrap();
+        assert!(
+            calc.result.contains(RATES_SNAPSHOT_DATE),
+            "snapshot date should appear in result; got: {}",
+            calc.result
+        );
+    }
+
+    #[test]
+    fn lowercase_codes_are_accepted() {
+        assert!(detect("100 usd to eur").is_some());
+    }
+
+    #[test]
+    fn mixed_case_codes_are_accepted() {
+        assert!(detect("100 Usd to Eur").is_some());
+    }
+
+    #[test]
+    fn unknown_currency_is_not_detected() {
+        assert!(detect("100 XYZ to EUR").is_none());
+        assert!(detect("100 USD to XYZ").is_none());
+    }
+
+    #[test]
+    fn in_is_accepted_as_connector() {
+        assert!(detect("100 USD in EUR").is_some());
+    }
+
+    #[test]
+    fn non_numeric_amount_is_not_detected() {
+        assert!(detect("some USD to EUR").is_none());
+    }
+
+    #[test]
+    fn wrong_token_count_is_not_detected() {
+        assert!(detect("100 USD").is_none());
+        assert!(detect("100 USD to EUR extra").is_none());
+    }
+
+    #[test]
+    fn ordinary_search_queries_are_not_detected() {
+        assert!(detect("usd").is_none());
+        assert!(detect("exchange rate").is_none());
+        assert!(detect("100 apples to oranges").is_none());
+    }
+}

--- a/src-tauri/src/calculator/mod.rs
+++ b/src-tauri/src/calculator/mod.rs
@@ -1,0 +1,155 @@
+//! WAT-203: inline calculator + unit/currency conversion.
+//!
+//! The launcher's highest-frequency "I wish Watson did this" feature. Runs
+//! as the very first step in the search pipeline: if [`detect`] returns
+//! `Some(Calculation)`, the caller short-circuits and shows that single
+//! result — typing `12*37` should not return an app named "1237".
+//!
+//! ## Routing
+//!
+//! [`detect`] tries, in order:
+//! 1. [`units::detect`] — `30 C to F`, `5 miles to km`, etc.
+//! 2. [`currency::detect`] — `100 USD to EUR`.
+//! 3. [`arithmetic::detect`] — `12 * 37`, `sqrt(144)`, `(1+2)^3`.
+//!
+//! Unit/currency conversion is tried before arithmetic because a query
+//! like `5 m to km` would otherwise partially parse as arithmetic (`5`
+//! followed by noise, which meval rejects anyway — but avoiding the
+//! wasted call is cleaner).
+//!
+//! ## False-positive discipline
+//!
+//! The hard rule, documented by tests in each submodule: queries like
+//! `apple`, `chrome`, `1.0`, `i5 cpu`, `5gb` must return `None`. A single
+//! number alone (`42`) is not a useful result, so arithmetic requires at
+//! least one operator or function call to fire.
+
+pub mod arithmetic;
+pub mod currency;
+pub mod units;
+
+use serde::{Deserialize, Serialize};
+
+/// A successful calculation result, ready to render as a search result.
+/// The caller turns this into a `SearchResult` with action `CopyClipboard`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Calculation {
+    /// Echoes the user's input, normalized. Rendered as the result's name.
+    pub expression: String,
+    /// Formatted result to display and to copy to clipboard on Enter.
+    pub result: String,
+    /// Which detector produced this result — useful for icon selection and
+    /// tests.
+    pub kind: CalculationKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CalculationKind {
+    Arithmetic,
+    UnitConversion,
+    CurrencyConversion,
+}
+
+/// Try to interpret `query` as a calculation. Returns `None` if the query
+/// doesn't look like one — the caller continues with normal search.
+pub fn detect(query: &str) -> Option<Calculation> {
+    let trimmed = query.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Order matters: unit/currency parsers are more specific (they require
+    // a `to|in` token) and would otherwise be missed because meval would
+    // reject the surrounding unit names.
+    if let Some(calc) = units::detect(trimmed) {
+        return Some(calc);
+    }
+    if let Some(calc) = currency::detect(trimmed) {
+        return Some(calc);
+    }
+    arithmetic::detect(trimmed)
+}
+
+/// Format a floating-point result for display. Trims insignificant
+/// trailing zeros ("12.500000" → "12.5", "12.000000" → "12") while
+/// preserving enough precision for scientific work. Shared across the
+/// arithmetic and conversion evaluators so all output formats identically.
+pub(crate) fn format_number(n: f64) -> String {
+    if !n.is_finite() {
+        return if n.is_nan() { "NaN".to_string() } else { "∞".to_string() };
+    }
+    // Use up to 10 significant digits then strip trailing zeros. Avoids
+    // scientific notation for everyday numbers (12.5, 3.14, -273.15) while
+    // keeping very small/large numbers readable.
+    let formatted = format!("{n:.10}");
+    if formatted.contains('.') {
+        let trimmed = formatted.trim_end_matches('0').trim_end_matches('.');
+        trimmed.to_string()
+    } else {
+        formatted
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_is_not_a_calculation() {
+        assert!(detect("").is_none());
+        assert!(detect("   ").is_none());
+    }
+
+    #[test]
+    fn plain_words_are_not_calculations() {
+        // Zero-false-positive discipline: common search queries must
+        // never look like calculations.
+        for non_calc in ["apple", "chrome", "firefox", "hello world", "i5 cpu", "5gb", "3d modeling", "1.0"] {
+            assert!(
+                detect(non_calc).is_none(),
+                "'{non_calc}' should not be detected as a calculation"
+            );
+        }
+    }
+
+    #[test]
+    fn arithmetic_query_routes_to_arithmetic_kind() {
+        let calc = detect("2+2").unwrap();
+        assert_eq!(calc.kind, CalculationKind::Arithmetic);
+    }
+
+    #[test]
+    fn unit_query_routes_to_unit_conversion_kind() {
+        let calc = detect("30 C to F").unwrap();
+        assert_eq!(calc.kind, CalculationKind::UnitConversion);
+    }
+
+    #[test]
+    fn currency_query_routes_to_currency_conversion_kind() {
+        let calc = detect("100 USD to EUR").unwrap();
+        assert_eq!(calc.kind, CalculationKind::CurrencyConversion);
+    }
+
+    // --- format_number ---
+
+    #[test]
+    fn format_number_trims_trailing_zeros() {
+        assert_eq!(format_number(12.5), "12.5");
+        assert_eq!(format_number(12.0), "12");
+        assert_eq!(format_number(12.500), "12.5");
+    }
+
+    #[test]
+    fn format_number_preserves_precision_without_noise() {
+        assert_eq!(format_number(3.14), "3.14");
+        assert_eq!(format_number(-273.15), "-273.15");
+    }
+
+    #[test]
+    fn format_number_handles_infinity_and_nan() {
+        assert_eq!(format_number(f64::NAN), "NaN");
+        assert_eq!(format_number(f64::INFINITY), "∞");
+        assert_eq!(format_number(f64::NEG_INFINITY), "∞");
+    }
+}

--- a/src-tauri/src/calculator/units.rs
+++ b/src-tauri/src/calculator/units.rs
@@ -1,0 +1,278 @@
+//! Unit conversion for WAT-203.
+//!
+//! Supports three dimensions: temperature, length, weight. Parses queries
+//! of the form `<number> <from> (to|in) <to>`. Both units must be known
+//! AND belong to the same dimension — otherwise we fall through and the
+//! caller tries arithmetic (which will also fail, so the query falls to
+//! fuzzy search).
+//!
+//! Conversion approach: each dimension has a reference unit (Kelvin,
+//! meters, grams). Every known unit knows how to convert to/from its
+//! reference. Cross-unit conversion is therefore: input → reference →
+//! output, which keeps the table linear in the number of units.
+
+use super::{format_number, Calculation, CalculationKind};
+
+/// Parsed `<amount> <from> (to|in) <to>` pattern.
+struct ParsedQuery<'a> {
+    amount: f64,
+    from: &'a str,
+    to: &'a str,
+}
+
+fn parse(query: &str) -> Option<ParsedQuery<'_>> {
+    // Split on whitespace; expect exactly 4 tokens: <number> <from_unit>
+    // <"to"|"in"> <to_unit>. If there are more, the query is too complex
+    // for our narrow pattern — fall through.
+    let tokens: Vec<&str> = query.split_whitespace().collect();
+    if tokens.len() != 4 {
+        return None;
+    }
+    let amount: f64 = tokens[0].parse().ok()?;
+    let connector = tokens[2].to_ascii_lowercase();
+    if connector != "to" && connector != "in" {
+        return None;
+    }
+    Some(ParsedQuery {
+        amount,
+        from: tokens[1],
+        to: tokens[3],
+    })
+}
+
+pub fn detect(query: &str) -> Option<Calculation> {
+    let parsed = parse(query)?;
+
+    // Try each dimension. First match wins. If the dimensions disagree
+    // (e.g. `5 m to kg`) neither will claim it and we fall through.
+    let (result_value, canonical_from, canonical_to) =
+        if let Some(r) = convert_temperature(parsed.amount, parsed.from, parsed.to) {
+            r
+        } else if let Some(r) = convert_length(parsed.amount, parsed.from, parsed.to) {
+            r
+        } else if let Some(r) = convert_weight(parsed.amount, parsed.from, parsed.to) {
+            r
+        } else {
+            return None;
+        };
+
+    Some(Calculation {
+        expression: format!(
+            "{} {} to {}",
+            format_number(parsed.amount),
+            canonical_from,
+            canonical_to
+        ),
+        result: format!("{} {}", format_number(result_value), canonical_to),
+        kind: CalculationKind::UnitConversion,
+    })
+}
+
+// --- Temperature ---
+
+/// Match case-insensitively. Accept common variants — `C`, `°C`, `celsius`,
+/// `celcius` (common typo). Returns canonical display form.
+fn canonicalize_temperature(unit: &str) -> Option<&'static str> {
+    let lower = unit.to_ascii_lowercase();
+    match lower.trim_start_matches('°') {
+        "c" | "celsius" | "celcius" => Some("°C"),
+        "f" | "fahrenheit" => Some("°F"),
+        "k" | "kelvin" => Some("K"),
+        _ => None,
+    }
+}
+
+fn convert_temperature(amount: f64, from: &str, to: &str) -> Option<(f64, &'static str, &'static str)> {
+    let from_c = canonicalize_temperature(from)?;
+    let to_c = canonicalize_temperature(to)?;
+    // Convert input to Kelvin then Kelvin to output.
+    let kelvin = match from_c {
+        "°C" => amount + 273.15,
+        "°F" => (amount - 32.0) * 5.0 / 9.0 + 273.15,
+        "K" => amount,
+        _ => unreachable!(),
+    };
+    let out = match to_c {
+        "°C" => kelvin - 273.15,
+        "°F" => (kelvin - 273.15) * 9.0 / 5.0 + 32.0,
+        "K" => kelvin,
+        _ => unreachable!(),
+    };
+    Some((out, from_c, to_c))
+}
+
+// --- Length ---
+
+/// Returns (meters_per_unit, canonical_display_form) or None.
+fn length_in_meters(unit: &str) -> Option<(f64, &'static str)> {
+    let lower = unit.to_ascii_lowercase();
+    Some(match lower.as_str() {
+        "mm" | "millimeter" | "millimeters" => (0.001, "mm"),
+        "cm" | "centimeter" | "centimeters" => (0.01, "cm"),
+        "m" | "meter" | "meters" => (1.0, "m"),
+        "km" | "kilometer" | "kilometers" => (1000.0, "km"),
+        "in" | "inch" | "inches" => (0.0254, "in"),
+        "ft" | "foot" | "feet" => (0.3048, "ft"),
+        "yd" | "yard" | "yards" => (0.9144, "yd"),
+        "mi" | "mile" | "miles" => (1609.344, "mi"),
+        _ => return None,
+    })
+}
+
+fn convert_length(amount: f64, from: &str, to: &str) -> Option<(f64, &'static str, &'static str)> {
+    let (from_m, from_c) = length_in_meters(from)?;
+    let (to_m, to_c) = length_in_meters(to)?;
+    Some((amount * from_m / to_m, from_c, to_c))
+}
+
+// --- Weight (mass, pedantically) ---
+
+fn weight_in_grams(unit: &str) -> Option<(f64, &'static str)> {
+    let lower = unit.to_ascii_lowercase();
+    Some(match lower.as_str() {
+        "g" | "gram" | "grams" => (1.0, "g"),
+        "kg" | "kilogram" | "kilograms" => (1000.0, "kg"),
+        "mg" | "milligram" | "milligrams" => (0.001, "mg"),
+        "lb" | "lbs" | "pound" | "pounds" => (453.592, "lb"),
+        "oz" | "ounce" | "ounces" => (28.3495, "oz"),
+        _ => return None,
+    })
+}
+
+fn convert_weight(amount: f64, from: &str, to: &str) -> Option<(f64, &'static str, &'static str)> {
+    let (from_g, from_c) = weight_in_grams(from)?;
+    let (to_g, to_c) = weight_in_grams(to)?;
+    Some((amount * from_g / to_g, from_c, to_c))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn r(query: &str) -> String {
+        detect(query)
+            .unwrap_or_else(|| panic!("expected '{query}' to be detected as unit conversion"))
+            .result
+    }
+
+    // --- temperature ---
+
+    #[test]
+    fn celsius_to_fahrenheit() {
+        assert_eq!(r("100 C to F"), "212 °F");
+        assert_eq!(r("0 C to F"), "32 °F");
+        assert_eq!(r("-40 C to F"), "-40 °F");
+    }
+
+    #[test]
+    fn fahrenheit_to_celsius() {
+        assert_eq!(r("32 F to C"), "0 °C");
+        assert_eq!(r("212 F to C"), "100 °C");
+    }
+
+    #[test]
+    fn celsius_to_kelvin_absolute_zero() {
+        assert_eq!(r("-273.15 C to K"), "0 K");
+    }
+
+    #[test]
+    fn temperature_accepts_long_forms() {
+        assert!(detect("100 celsius to fahrenheit").is_some());
+        // Tolerate the common typo "celcius" — user doesn't need to know
+        // they misspelled it. The output still shows the correct "°C".
+        let calc = detect("100 celcius to F").unwrap();
+        assert!(calc.expression.contains("°C"));
+    }
+
+    #[test]
+    fn temperature_with_in_keyword() {
+        assert_eq!(r("100 C in F"), "212 °F");
+    }
+
+    // --- length ---
+
+    #[test]
+    fn miles_to_km() {
+        let calc = detect("1 mi to km").unwrap();
+        assert_eq!(calc.result, "1.609344 km");
+    }
+
+    #[test]
+    fn km_to_m() {
+        assert_eq!(r("5 km to m"), "5000 m");
+    }
+
+    #[test]
+    fn inches_to_cm() {
+        assert_eq!(r("1 in to cm"), "2.54 cm");
+    }
+
+    #[test]
+    fn length_accepts_long_forms() {
+        assert!(detect("5 miles to kilometers").is_some());
+        assert!(detect("1 foot to inches").is_some());
+    }
+
+    // --- weight ---
+
+    #[test]
+    fn kg_to_lb() {
+        let calc = detect("1 kg to lb").unwrap();
+        // 1 kg = 2.20462... lb; not asserting exact decimal.
+        assert!(calc.result.starts_with("2.20"), "got: {}", calc.result);
+    }
+
+    #[test]
+    fn oz_to_g() {
+        let calc = detect("1 oz to g").unwrap();
+        assert_eq!(calc.result, "28.3495 g");
+    }
+
+    // --- dimension mismatch / noise ---
+
+    #[test]
+    fn cross_dimension_conversion_is_not_detected() {
+        // 5 meters → kilograms is nonsense; we must not silently pretend.
+        assert!(detect("5 m to kg").is_none());
+    }
+
+    #[test]
+    fn unknown_units_are_not_detected() {
+        assert!(detect("5 foobar to m").is_none());
+        assert!(detect("5 m to bazqux").is_none());
+    }
+
+    #[test]
+    fn wrong_token_count_is_not_detected() {
+        // Our parser is strict — 4 whitespace-separated tokens exactly.
+        assert!(detect("5 miles").is_none());
+        assert!(detect("5 miles to km somewhere").is_none());
+        assert!(detect("5mi to km").is_none(), "no space between number and unit");
+    }
+
+    #[test]
+    fn missing_connector_is_not_detected() {
+        assert!(detect("5 m kg").is_none());
+        assert!(detect("5 miles and km").is_none());
+    }
+
+    #[test]
+    fn non_numeric_amount_is_not_detected() {
+        assert!(detect("many miles to km").is_none());
+    }
+
+    #[test]
+    fn ordinary_search_queries_are_not_detected() {
+        // Pin zero-false-positive: common queries.
+        assert!(detect("apple").is_none());
+        assert!(detect("to do list").is_none());
+        assert!(detect("go to sleep").is_none());
+    }
+
+    #[test]
+    fn temperature_case_insensitive() {
+        assert!(detect("100 c to f").is_some());
+        assert!(detect("100 C to F").is_some());
+        assert!(detect("100 CELSIUS to FAHRENHEIT").is_some());
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod actions;
+mod calculator;
 mod clipboard;
 mod config;
 mod db;
@@ -116,6 +117,31 @@ fn files_route_results(state: &State<AppState>, sub: SubQuery) -> Vec<SearchResu
         .unwrap_or_default()
 }
 
+/// Wrap a successful calculation into the single `SearchResult` the UI
+/// renders. WAT-203 short-circuits the pipeline on detection, so this is
+/// the only result returned for a calculator query.
+fn calculation_result(calc: calculator::Calculation) -> SearchResult {
+    // The id is derived from the expression so identical repeats reuse
+    // the same result row (stable for React keying and de-dup).
+    let id = format!("calc:{}", calc.expression);
+    // Copy only the plain result value — not the "rates from ..." suffix
+    // on currency — so pasting somewhere else gives a clean number.
+    let copy_value = calc
+        .result
+        .split_once(" (")
+        .map(|(head, _)| head.to_string())
+        .unwrap_or_else(|| calc.result.clone());
+    SearchResult {
+        id,
+        name: format!("{} = {}", calc.expression, calc.result),
+        description: "Press Enter to copy".to_string(),
+        icon: Some("calculator".to_string()),
+        result_type: ResultType::Calculation,
+        score: 100000, // Above everything else; we've already short-circuited.
+        action: SearchAction::CopyClipboard { content: copy_value },
+    }
+}
+
 fn clipboard_route_results(state: &State<AppState>, sub: SubQuery) -> Vec<SearchResult> {
     let entries = match sub {
         SubQuery::Listing => state.clipboard.get_history(),
@@ -139,6 +165,14 @@ fn clipboard_route_results(state: &State<AppState>, sub: SubQuery) -> Vec<Search
 
 #[tauri::command]
 fn search(query: String, state: State<AppState>) -> Vec<SearchResult> {
+    // WAT-203: inline calculator runs first and short-circuits when the
+    // query looks like math or a unit/currency conversion. The detector
+    // is conservative — ordinary search queries ("apple", "chrome",
+    // "iphone 15") fall through to the normal pipeline.
+    if let Some(calc) = calculator::detect(&query) {
+        return vec![calculation_result(calc)];
+    }
+
     match classify_prefix_route(&query) {
         Route::Empty => return vec![],
         Route::Notes(sub) => return notes_route_results(&state, sub),

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -25,6 +25,9 @@ pub enum ResultType {
     Clipboard,
     Note,
     File,
+    /// WAT-203: inline calculation result (arithmetic, unit conversion,
+    /// currency). The action is always `CopyClipboard { content: result }`.
+    Calculation,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -79,6 +79,26 @@ function FileIcon() {
   );
 }
 
+function CalculatorIcon() {
+  return (
+    <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-rose-400 to-pink-600 flex items-center justify-center">
+      <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <rect x="4" y="2" width="16" height="20" rx="2" />
+        <line x1="8" y1="6" x2="16" y2="6" />
+        <line x1="8" y1="10" x2="8.01" y2="10" />
+        <line x1="12" y1="10" x2="12.01" y2="10" />
+        <line x1="16" y1="10" x2="16.01" y2="10" />
+        <line x1="8" y1="14" x2="8.01" y2="14" />
+        <line x1="12" y1="14" x2="12.01" y2="14" />
+        <line x1="16" y1="14" x2="16.01" y2="14" />
+        <line x1="8" y1="18" x2="8.01" y2="18" />
+        <line x1="12" y1="18" x2="12.01" y2="18" />
+        <line x1="16" y1="18" x2="16.01" y2="18" />
+      </svg>
+    </div>
+  );
+}
+
 function DefaultIcon() {
   return (
     <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-gray-400 to-gray-600 flex items-center justify-center">
@@ -105,6 +125,8 @@ export function ResultItem({ result, isSelected, onClick, index }: ResultItemPro
         return <NoteIcon />;
       case 'file':
         return <FileIcon />;
+      case 'calculation':
+        return <CalculatorIcon />;
       default:
         return <DefaultIcon />;
     }
@@ -124,6 +146,8 @@ export function ResultItem({ result, isSelected, onClick, index }: ResultItemPro
         return 'Note';
       case 'file':
         return 'File';
+      case 'calculation':
+        return 'Calc';
       default:
         return '';
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface SearchResult {
   name: string;
   description: string;
   icon: string | null;
-  result_type: 'application' | 'web_search' | 'system_command' | 'clipboard' | 'note' | 'file';
+  result_type: 'application' | 'web_search' | 'system_command' | 'clipboard' | 'note' | 'file' | 'calculation';
   score: number;
   action: SearchAction;
 }


### PR DESCRIPTION
## Summary
- New `calculator` module: arithmetic (meval), unit conversion (temperature / length / weight), currency (offline rate table).
- Runs **first** in the search pipeline; short-circuits the rest of the pipeline when a calculation is detected.
- `ResultType::Calculation` + `CopyClipboard` action so Enter copies the result.
- Conservative detector — 54 tests include explicit zero-false-positive checks on `apple`, `iphone 15`, `i5 cpu`, `3d modeling`, `5gb`, `to do list`, `go to sleep`.

Closes #11.

## Examples
| Query | Result |
|---|---|
| `12 * 37` | `444` |
| `sqrt(144)` | `12` |
| `(1+2)^3` | `27` |
| `30 C to F` | `86 °F` |
| `5 miles to km` | `8.04672 km` |
| `1 kg to lb` | `2.2046226218 lb` |
| `100 USD to EUR` | `92 EUR (rates from 2026-04-01)` |

## Architecture
Detector order: units → currency → arithmetic. Unit/currency parsers are more specific (require `to|in` token) so they get first shot; meval then handles the general arithmetic case. Each submodule is independently tested; `calculator::detect` tests pin the routing.

Copy-to-clipboard strips the `(rates from …)` suffix so a currency result pastes as a clean number.

## Test plan
- [x] `cargo test` — 244 passed (+54)
- [x] `npm test` — 26 passed
- [x] `npm run build` — clean
- [ ] Manual: type `12*37`, `30 C to F`, `100 USD to EUR`; verify single result appears, Enter copies the number; type `apple`, `iphone 15`, `firefox 1.0` — normal search, no calculator hijack.

## Notes on stale currency rates
The offline table has a `RATES_SNAPSHOT_DATE` constant shown in every currency result ("rates from 2026-04-01"). This is a deliberate tradeoff: reliable offline behavior for everyday conversions, with an honest disclosure so nobody uses it for high-stakes work. A follow-up ticket can add a weekly refresh against a free forex API without changing the caller's contract.

## Dependencies
Added `meval = "0.2"` — small pure-Rust math expression parser (~800 LOC). Evaluated alternatives: `evalexpr` (heavier, more general), `fasteval` (similar but looser parse). meval hits the sweet spot of "handles what users expect, rejects everything else cleanly."

🤖 Generated with [Claude Code](https://claude.com/claude-code)