### PR TITLE
WAT-305: Markdown preview toggle in NoteEditor

### DIFF
--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAppStore } from '../stores/app';
+import { renderMarkdown } from '../lib/markdown';
 
 export function NoteEditor() {
   const { currentNote, createNote, updateNote, deleteNote, closeNoteEditor, reloadNoteFromDisk } =
@@ -8,6 +9,10 @@ export function NoteEditor() {
   const [content, setContent] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [isReconciling, setIsReconciling] = useState(false);
+  // WAT-305: toggled via Cmd/Ctrl+P or the header button. Local state
+  // because preview mode is a viewing preference, not a persisted one —
+  // reopening a note always starts in edit mode.
+  const [isPreviewing, setIsPreviewing] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
 
@@ -15,10 +20,12 @@ export function NoteEditor() {
     if (currentNote) {
       setTitle(currentNote.title);
       setContent(currentNote.content);
+      setIsPreviewing(false);
       contentRef.current?.focus();
     } else {
       setTitle('');
       setContent('');
+      setIsPreviewing(false);
       titleRef.current?.focus();
     }
   }, [currentNote]);
@@ -75,6 +82,10 @@ export function NoteEditor() {
     } else if (e.key === 's' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       handleSave();
+    } else if (e.key === 'p' && (e.metaKey || e.ctrlKey)) {
+      // WAT-305: Cmd/Ctrl+P toggles markdown preview.
+      e.preventDefault();
+      setIsPreviewing((p) => !p);
     }
   };
 
@@ -86,6 +97,19 @@ export function NoteEditor() {
           {currentNote ? 'Edit Note' : 'New Note'}
         </h3>
         <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setIsPreviewing((p) => !p)}
+            aria-pressed={isPreviewing}
+            title="Toggle markdown preview (Cmd/Ctrl+P)"
+            className={`px-2 py-1 text-xs rounded transition-colors ${
+              isPreviewing
+                ? 'bg-blue-500 text-white'
+                : 'text-gray-500 hover:bg-[var(--selected)]'
+            }`}
+          >
+            {isPreviewing ? 'Edit' : 'Preview'}
+          </button>
           {currentNote && (
             <button
               onClick={handleDelete}
@@ -147,13 +171,27 @@ export function NoteEditor() {
         className="w-full px-3 py-2 mb-3 text-sm font-medium bg-[var(--input-bg)] border border-[var(--border)] rounded-lg outline-none focus:ring-1 focus:ring-blue-500"
       />
 
-      <textarea
-        ref={contentRef}
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        placeholder="Write your note... Use #tags to organize"
-        className="w-full h-48 p-3 text-sm bg-[var(--input-bg)] border border-[var(--border)] rounded-lg resize-none outline-none focus:ring-1 focus:ring-blue-500"
-      />
+      {isPreviewing ? (
+        <div
+          role="article"
+          aria-label="Markdown preview"
+          className="w-full h-48 p-3 text-sm bg-[var(--input-bg)] border border-[var(--border)] rounded-lg overflow-y-auto"
+        >
+          {content.trim() === '' ? (
+            <p className="text-gray-400 italic">Nothing to preview yet.</p>
+          ) : (
+            renderMarkdown(content)
+          )}
+        </div>
+      ) : (
+        <textarea
+          ref={contentRef}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          placeholder="Write your note... Use #tags to organize"
+          className="w-full h-48 p-3 text-sm bg-[var(--input-bg)] border border-[var(--border)] rounded-lg resize-none outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      )}
 
       <div className="flex justify-between items-center mt-3">
         <p className="text-xs text-gray-400">

--- a/src/components/__tests__/NoteEditor.test.tsx
+++ b/src/components/__tests__/NoteEditor.test.tsx
@@ -141,4 +141,53 @@ describe('NoteEditor — WAT-204 reconcile banner', () => {
     expect(args.title).toBe('Meeting Notes');
     expect(args.content).toBe('body');
   });
+
+  // --- WAT-305 markdown preview toggle ---
+
+  it('starts in edit mode with the textarea visible', () => {
+    useAppStore.setState({ currentNote: note({ content: '# hello' }) });
+    render(<NoteEditor />);
+    expect(screen.getByPlaceholderText(/write your note/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('article', { name: /markdown preview/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('toggles to preview mode when the Preview button is clicked', async () => {
+    useAppStore.setState({ currentNote: note({ content: '# hello\n\nworld' }) });
+    const user = userEvent.setup();
+    render(<NoteEditor />);
+
+    await user.click(screen.getByRole('button', { name: /preview/i, pressed: false }));
+
+    // Textarea gone; article + rendered h1 present.
+    expect(screen.queryByPlaceholderText(/write your note/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('article', { name: /markdown preview/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1, name: 'hello' })).toBeInTheDocument();
+  });
+
+  it('toggles back to edit when the button is clicked again', async () => {
+    useAppStore.setState({ currentNote: note({ content: 'body' }) });
+    const user = userEvent.setup();
+    render(<NoteEditor />);
+
+    const toggle = screen.getByRole('button', { name: /preview/i });
+    await user.click(toggle);
+    // Button label flips to "Edit" and aria-pressed is true.
+    const backToEdit = screen.getByRole('button', { name: /edit/i, pressed: true });
+    await user.click(backToEdit);
+
+    expect(screen.getByPlaceholderText(/write your note/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('article', { name: /markdown preview/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows a placeholder in preview mode when the buffer is empty', async () => {
+    useAppStore.setState({ currentNote: note({ content: '   \n\n  ' }) });
+    const user = userEvent.setup();
+    render(<NoteEditor />);
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+    expect(screen.getByText(/nothing to preview yet/i)).toBeInTheDocument();
+  });
 });

--- a/src/lib/__tests__/markdown.test.tsx
+++ b/src/lib/__tests__/markdown.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { renderMarkdown } from '../markdown';
+
+describe('renderMarkdown — WAT-305 preview', () => {
+  // --- headings ---
+
+  it('renders ATX h1 through h6', () => {
+    render(<>{renderMarkdown('# One\n\n## Two\n\n### Three\n\n#### Four\n\n##### Five\n\n###### Six')}</>);
+    expect(screen.getByRole('heading', { level: 1, name: 'One' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: 'Two' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Three' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 4, name: 'Four' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 5, name: 'Five' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 6, name: 'Six' })).toBeInTheDocument();
+  });
+
+  it('requires a space between # and heading text', () => {
+    // `#tag` is a literal — common in notes that use hashtags.
+    const { container } = render(<>{renderMarkdown('#tag not a heading')}</>);
+    expect(container.querySelector('h1')).toBeNull();
+    expect(container.textContent).toContain('#tag not a heading');
+  });
+
+  // --- lists ---
+
+  it('renders unordered lists with both marker styles', () => {
+    const { container } = render(<>{renderMarkdown('- one\n- two\n* three')}</>);
+    // Consecutive `-` then `*` produce a single ul (regex treats them
+    // as equivalent markers), which matches Markdown convention.
+    const lists = container.querySelectorAll('ul');
+    expect(lists.length).toBeGreaterThanOrEqual(1);
+    const items = container.querySelectorAll('li');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe('one');
+    expect(items[2].textContent).toBe('three');
+  });
+
+  it('renders ordered lists', () => {
+    const { container } = render(<>{renderMarkdown('1. first\n2. second\n3. third')}</>);
+    expect(container.querySelector('ol')).not.toBeNull();
+    const items = container.querySelectorAll('li');
+    expect(items.length).toBe(3);
+    expect(items[0].textContent).toBe('first');
+    expect(items[2].textContent).toBe('third');
+  });
+
+  // --- code ---
+
+  it('renders fenced code blocks verbatim', () => {
+    const src = '```\nlet x = 1;\n// comment\n```';
+    const { container } = render(<>{renderMarkdown(src)}</>);
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe('let x = 1;\n// comment');
+  });
+
+  it('tolerates unclosed code fence (common hand-edit mistake)', () => {
+    // File ends without a closing ```; renderer must not infinite-loop
+    // or crash.
+    const { container } = render(<>{renderMarkdown('```\nstill writing')}</>);
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe('still writing');
+  });
+
+  it('renders inline code with backtick delimiters', () => {
+    const { container } = render(<>{renderMarkdown('use `npm test` to run')}</>);
+    const code = container.querySelector('code');
+    expect(code).not.toBeNull();
+    expect(code?.textContent).toBe('npm test');
+  });
+
+  // --- inline emphasis ---
+
+  it('renders bold and italic', () => {
+    const { container } = render(<>{renderMarkdown('**bold** and *italic*')}</>);
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+    expect(container.querySelector('em')?.textContent).toBe('italic');
+  });
+
+  it('does not render italic when asterisks are adjacent to spaces', () => {
+    // Avoids false-positive emphasis on normal prose: "you * me * them".
+    const { container } = render(<>{renderMarkdown('you * me * them')}</>);
+    expect(container.querySelector('em')).toBeNull();
+  });
+
+  // --- links ---
+
+  it('renders http and https links as clickable anchors', () => {
+    render(<>{renderMarkdown('See [docs](https://example.com/docs).')}</>);
+    const link = screen.getByRole('link', { name: 'docs' });
+    expect(link).toHaveAttribute('href', 'https://example.com/docs');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders mailto links', () => {
+    render(<>{renderMarkdown('Contact [support](mailto:help@example.com)')}</>);
+    expect(screen.getByRole('link', { name: 'support' })).toHaveAttribute(
+      'href',
+      'mailto:help@example.com',
+    );
+  });
+
+  it('refuses javascript: URLs and renders them as plain text', () => {
+    // Security pin: even though we never render HTML strings, a
+    // javascript: href on a React <a> would still be a vulnerability.
+    // The allowlist keeps those out of the DOM entirely.
+    const { container } = render(
+      <>{renderMarkdown('[click](javascript:alert(1))')}</>,
+    );
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('[click](javascript:alert(1))');
+  });
+
+  it('refuses data: URLs', () => {
+    const { container } = render(
+      <>{renderMarkdown('[img](data:text/html;base64,PHNjcmlwdD4=)')}</>,
+    );
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  // --- XSS by-construction ---
+
+  it('renders raw HTML input as literal text, not as DOM', () => {
+    // We use React children (string) rather than dangerouslySetInnerHTML,
+    // so an <img onerror=...> tag in the source becomes literal text.
+    // Pin that property — a future refactor using innerHTML would break
+    // this test.
+    const nasty = '<img src=x onerror="alert(1)">';
+    const { container } = render(<>{renderMarkdown(nasty)}</>);
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain(nasty);
+  });
+
+  // --- paragraphs ---
+
+  it('splits paragraphs on blank lines', () => {
+    const { container } = render(<>{renderMarkdown('first line\nsecond line\n\nthird block')}</>);
+    const paras = container.querySelectorAll('p');
+    expect(paras.length).toBe(2);
+  });
+
+  it('breaks out of a paragraph on a heading', () => {
+    const { container } = render(<>{renderMarkdown('start of para\n# heading\ntail')}</>);
+    expect(container.querySelector('h1')?.textContent).toBe('heading');
+    // The paragraphs before/after are separate; "tail" is its own paragraph.
+    expect(container.querySelectorAll('p').length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/lib/markdown.tsx
+++ b/src/lib/markdown.tsx
@@ -1,0 +1,288 @@
+import React from 'react';
+
+/**
+ * WAT-305: minimal markdown renderer for the note preview toggle.
+ *
+ * Implemented as a pure-React tree: we never build HTML strings or use
+ * `dangerouslySetInnerHTML`, so the rendered output carries no XSS
+ * surface regardless of what the user types. The tradeoff is coverage —
+ * we support only the subset listed below. Users who write HTML tags in
+ * their notes see the tags as literal text in preview.
+ *
+ * Supported:
+ * - ATX headings (# .. ######)
+ * - Unordered lists (- or *)
+ * - Ordered lists (1. 2. 3.)
+ * - Code fences (``` ... ```)
+ * - Inline code (`...`)
+ * - Bold (**...**)
+ * - Italic (*...*) — only well-formed single-asterisk pairs; list
+ *   markers are consumed at block level so no ambiguity here
+ * - Links [text](url) — URL passes an allowlist (http, https, mailto,
+ *   relative, anchor); anything else (javascript:, data:, etc.) is
+ *   rendered as plain text
+ * - Paragraphs (blank-line separated)
+ *
+ * Not supported (literal text):
+ * - Tables, blockquotes, horizontal rules, images, reference links,
+ *   footnotes, task lists, HTML passthrough.
+ */
+
+/** Whether a href is safe to render as a clickable link. */
+function isSafeUrl(url: string): boolean {
+  const lower = url.trim().toLowerCase();
+  return (
+    lower.startsWith('http://') ||
+    lower.startsWith('https://') ||
+    lower.startsWith('mailto:') ||
+    lower.startsWith('/') ||
+    lower.startsWith('#')
+  );
+}
+
+/**
+ * Render a single line of inline markdown into a list of React nodes.
+ * Single-pass: at each position, try the token patterns in priority
+ * order; if none match, append the character to the plain-text buffer.
+ */
+function renderInline(text: string, keyPrefix: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  let buffer = '';
+  let i = 0;
+  let nodeCounter = 0;
+
+  const flush = () => {
+    if (buffer) {
+      nodes.push(buffer);
+      buffer = '';
+    }
+  };
+  const pushNode = (node: React.ReactNode) => {
+    flush();
+    nodes.push(node);
+    nodeCounter++;
+  };
+
+  while (i < text.length) {
+    const ch = text[i];
+
+    // Inline code: `...`. Highest priority — contents are literal, no
+    // nested markup.
+    if (ch === '`') {
+      const end = text.indexOf('`', i + 1);
+      if (end !== -1) {
+        pushNode(
+          <code key={`${keyPrefix}-c${nodeCounter}`} className="px-1 py-0.5 bg-[var(--input-bg)] rounded text-xs font-mono">
+            {text.slice(i + 1, end)}
+          </code>,
+        );
+        i = end + 1;
+        continue;
+      }
+    }
+
+    // Bold: **...**. Must look for closing ** that's not immediately
+    // after the opening (empty emphasis like **** is ignored).
+    if (ch === '*' && text[i + 1] === '*') {
+      const end = text.indexOf('**', i + 2);
+      if (end !== -1 && end > i + 2) {
+        pushNode(
+          <strong key={`${keyPrefix}-b${nodeCounter}`}>
+            {renderInline(text.slice(i + 2, end), `${keyPrefix}-b${nodeCounter}`)}
+          </strong>,
+        );
+        i = end + 2;
+        continue;
+      }
+    }
+
+    // Italic: *...*. Single asterisk, not doubled. Require non-space
+    // immediately after the opener and before the closer so `a * b * c`
+    // doesn't become "a <em> b </em> c".
+    if (ch === '*' && text[i + 1] !== '*' && text[i + 1] !== ' ' && text[i + 1] !== undefined) {
+      // Scan for a closing single asterisk with non-space before it.
+      let j = i + 1;
+      while (j < text.length) {
+        if (text[j] === '*' && text[j + 1] !== '*' && text[j - 1] !== ' ') {
+          pushNode(
+            <em key={`${keyPrefix}-i${nodeCounter}`}>
+              {renderInline(text.slice(i + 1, j), `${keyPrefix}-i${nodeCounter}`)}
+            </em>,
+          );
+          i = j + 1;
+          break;
+        }
+        j++;
+      }
+      if (j < text.length) continue;
+      // No valid closer — fall through to plain-text handling.
+    }
+
+    // Link: [text](url). Greedy on text (no nested brackets), URL can't
+    // contain unescaped ')'.
+    if (ch === '[') {
+      const match = /^\[([^\]]+)\]\(([^)]+)\)/.exec(text.slice(i));
+      if (match) {
+        const [full, linkText, url] = match;
+        if (isSafeUrl(url)) {
+          pushNode(
+            <a
+              key={`${keyPrefix}-a${nodeCounter}`}
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 hover:underline"
+            >
+              {renderInline(linkText, `${keyPrefix}-a${nodeCounter}`)}
+            </a>,
+          );
+        } else {
+          // Unsafe protocol — render as plain text, keeping the syntax
+          // visible so the user knows the link didn't render. Safer than
+          // silently stripping.
+          pushNode(
+            <span key={`${keyPrefix}-u${nodeCounter}`} className="text-gray-400" title="Unsafe URL not rendered as a link">
+              {full}
+            </span>,
+          );
+        }
+        i += full.length;
+        continue;
+      }
+    }
+
+    buffer += ch;
+    i++;
+  }
+  flush();
+  return nodes;
+}
+
+/**
+ * Parse block-level markdown and render to a React tree. Blocks are
+ * separated by blank lines; each non-blank region becomes a single
+ * block element. Code fences and lists don't require preceding blank
+ * lines — they break out of the current paragraph on sight.
+ */
+export function renderMarkdown(source: string): React.ReactNode {
+  const lines = source.split(/\r?\n/);
+  const blocks: React.ReactNode[] = [];
+  let i = 0;
+
+  const isHeadingLine = (line: string) => /^#{1,6}\s+\S/.test(line);
+  const isUlLine = (line: string) => /^[-*]\s+\S/.test(line);
+  const isOlLine = (line: string) => /^\d+\.\s+\S/.test(line);
+  const isBreakout = (line: string) =>
+    line.startsWith('```') ||
+    isHeadingLine(line) ||
+    isUlLine(line) ||
+    isOlLine(line);
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code fence: opening ``` to closing ```, content rendered verbatim.
+    if (line.startsWith('```')) {
+      const start = i + 1;
+      let end = start;
+      while (end < lines.length && !lines[end].startsWith('```')) {
+        end++;
+      }
+      blocks.push(
+        <pre key={`pre-${i}`} className="p-2 my-2 bg-[var(--input-bg)] rounded overflow-x-auto text-xs font-mono">
+          <code>{lines.slice(start, end).join('\n')}</code>
+        </pre>,
+      );
+      // Skip past the closing fence if present; tolerate missing closer.
+      i = end < lines.length ? end + 1 : end;
+      continue;
+    }
+
+    // Heading.
+    const hMatch = /^(#{1,6})\s+(.+)$/.exec(line);
+    if (hMatch) {
+      const level = hMatch[1].length;
+      const content = renderInline(hMatch[2], `h-${i}`);
+      const key = `h-${i}`;
+      const className =
+        level === 1
+          ? 'text-xl font-bold mt-3 mb-2'
+          : level === 2
+            ? 'text-lg font-semibold mt-3 mb-2'
+            : 'text-base font-semibold mt-2 mb-1';
+      switch (level) {
+        case 1: blocks.push(<h1 key={key} className={className}>{content}</h1>); break;
+        case 2: blocks.push(<h2 key={key} className={className}>{content}</h2>); break;
+        case 3: blocks.push(<h3 key={key} className={className}>{content}</h3>); break;
+        case 4: blocks.push(<h4 key={key} className={className}>{content}</h4>); break;
+        case 5: blocks.push(<h5 key={key} className={className}>{content}</h5>); break;
+        default: blocks.push(<h6 key={key} className={className}>{content}</h6>); break;
+      }
+      i++;
+      continue;
+    }
+
+    // Unordered list.
+    if (isUlLine(line)) {
+      const start = i;
+      const items: string[] = [];
+      while (i < lines.length && isUlLine(lines[i])) {
+        items.push(lines[i].replace(/^[-*]\s+/, ''));
+        i++;
+      }
+      blocks.push(
+        <ul key={`ul-${start}`} className="list-disc ml-5 my-2 space-y-0.5">
+          {items.map((item, k) => (
+            <li key={k}>{renderInline(item, `ul-${start}-${k}`)}</li>
+          ))}
+        </ul>,
+      );
+      continue;
+    }
+
+    // Ordered list.
+    if (isOlLine(line)) {
+      const start = i;
+      const items: string[] = [];
+      while (i < lines.length && isOlLine(lines[i])) {
+        items.push(lines[i].replace(/^\d+\.\s+/, ''));
+        i++;
+      }
+      blocks.push(
+        <ol key={`ol-${start}`} className="list-decimal ml-5 my-2 space-y-0.5">
+          {items.map((item, k) => (
+            <li key={k}>{renderInline(item, `ol-${start}-${k}`)}</li>
+          ))}
+        </ol>,
+      );
+      continue;
+    }
+
+    // Blank line.
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+
+    // Paragraph: consume lines until a blank or a block breakout.
+    const paraStart = i;
+    const paraLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== '' &&
+      !isBreakout(lines[i])
+    ) {
+      paraLines.push(lines[i]);
+      i++;
+    }
+    if (paraLines.length > 0) {
+      blocks.push(
+        <p key={`p-${paraStart}`} className="my-2 leading-snug whitespace-pre-wrap">
+          {renderInline(paraLines.join('\n'), `p-${paraStart}`)}
+        </p>,
+      );
+    }
+  }
+
+  return <>{blocks}</>;
+}


### PR DESCRIPTION
## Summary
Header button or **Cmd/Ctrl+P** toggles the note editor between plain textarea and a rendered preview. The preview is pure React nodes — no HTML strings anywhere — so there's no XSS surface regardless of what the user types.

Closes #19.

## Supported subset
Block: ATX headings, unordered/ordered lists, fenced code, paragraphs.
Inline: bold, italic, inline code, links (http/https/mailto/relative/anchor allowlist).

Unsafe protocols (`javascript:`, `data:`, etc.) render as literal text so the user sees the markup wasn't rendered — safer than silently stripping.

## Not supported
Tables, blockquotes, hrules, images, reference links, footnotes, task lists, HTML passthrough. Raw `<img src=x onerror=...>` in the source becomes literal text in preview — pinned by a test.

## Why no `marked` + `DOMPurify`
+~20KB gz for a dep pair whose main job is to produce HTML strings we then sanitize. The hand-rolled renderer is ~5KB, has zero HTML-injection surface by construction (React children, never `dangerouslySetInnerHTML`), and the subset it covers is exactly what users type in a scratch-note app.

## Test plan
- [x] `npm test` — 50 passed (+20: 16 renderer + 4 NoteEditor integration)
- [x] `npm run build` — clean
- [ ] Manual: open a note, press Cmd/Ctrl+P, verify headings/lists/code/links render; edit, toggle back; try a note with `[click](javascript:alert(1))` — no <a> in the DOM.

## Design notes
- Italic requires non-space adjacency (`*word*`, not `* bullet-like *`) so ordinary prose isn't accidentally emphasized.
- Unclosed code fences render trailing content without crashing (common hand-edit mistake).
- `isPreviewing` is local state — reopening a note always starts in edit mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)