### PR TITLE
WAT-304: Recents carousel on empty query

### DIFF
--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -32,6 +32,10 @@ pub fn migrations() -> Migrations<'static> {
         // survive indexer runs and can be merged into the in-memory
         // `Vec<AppEntry>` cache on demand.
         M::up(SCHEMA_V002),
+        // 003 — WAT-304 file open stats. Same pattern as app_launches:
+        // a path-keyed side table so reindex doesn't clobber open
+        // history and we don't have to persist every file row's stats.
+        M::up(SCHEMA_V003),
     ])
 }
 
@@ -113,6 +117,15 @@ CREATE TABLE IF NOT EXISTS app_launches (
 );
 "#;
 
+const SCHEMA_V003: &str = r#"
+CREATE TABLE IF NOT EXISTS file_opens (
+    path TEXT PRIMARY KEY,
+    open_count INTEGER NOT NULL DEFAULT 0,
+    last_opened_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_file_opens_last_opened ON file_opens(last_opened_at);
+"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -136,7 +149,7 @@ mod tests {
             .unwrap();
         // Bump this expectation whenever a new migration is appended
         // to `migrations()`.
-        assert_eq!(version, 2);
+        assert_eq!(version, 3);
     }
 
     #[test]
@@ -148,7 +161,7 @@ mod tests {
         let version: i32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 2);
+        assert_eq!(version, 3);
     }
 
     #[test]
@@ -170,7 +183,7 @@ mod tests {
         let post: i32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(post, 2);
+        assert_eq!(post, 3);
     }
 
     #[test]
@@ -186,6 +199,7 @@ mod tests {
             "files",
             "scratchpad",
             "app_launches",
+            "file_opens",
         ] {
             let exists: i64 = conn
                 .query_row(

--- a/src-tauri/src/files/mod.rs
+++ b/src-tauri/src/files/mod.rs
@@ -150,6 +150,55 @@ impl FileSearchManager {
             )
             .map_err(|e| e.to_string())
     }
+
+    /// WAT-304: record that a file was opened. Upserts the `file_opens`
+    /// side table — keeps the stats decoupled from the indexer's
+    /// insert/replace loop so reindex doesn't wipe open history.
+    pub fn record_open(&self, path: &str) -> Result<(), String> {
+        self.db
+            .execute(
+                "INSERT INTO file_opens (path, open_count, last_opened_at) VALUES (?, 1, ?)
+                 ON CONFLICT(path) DO UPDATE SET
+                    open_count = open_count + 1,
+                    last_opened_at = excluded.last_opened_at",
+                &[&path, &Utc::now().timestamp()],
+            )
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    /// WAT-304: return the most recently opened files joined with their
+    /// current index entry. Files that have been opened but later
+    /// removed from the index (deleted on disk, indexer not re-run)
+    /// drop out — recents reflects "files Watson still knows about".
+    /// Returns `(entry, last_opened_at)` tuples so the caller can
+    /// interleave with app recents by timestamp.
+    pub fn get_recent_opened(&self, limit: usize) -> Result<Vec<(FileEntry, i64)>, String> {
+        self.db
+            .query_map(
+                "SELECT f.id, f.name, f.path, f.extension, f.size_bytes, f.modified_at,
+                        o.last_opened_at
+                 FROM file_opens o
+                 JOIN files f ON f.path = o.path
+                 ORDER BY o.last_opened_at DESC
+                 LIMIT ?",
+                &[&(limit as i64)],
+                |row| {
+                    Ok((
+                        FileEntry {
+                            id: row.get(0)?,
+                            name: row.get(1)?,
+                            path: row.get(2)?,
+                            extension: row.get(3)?,
+                            size_bytes: row.get(4)?,
+                            modified_at: row.get(5)?,
+                        },
+                        row.get(6)?,
+                    ))
+                },
+            )
+            .map_err(|e| e.to_string())
+    }
 }
 
 #[cfg(test)]
@@ -385,5 +434,118 @@ mod tests {
         let handle = mgr.cancel_flag();
         mgr.request_cancel();
         assert!(handle.load(Ordering::Relaxed));
+    }
+
+    // --- WAT-304: file open stats ---
+
+    fn inserted_mgr_with(files: &[FileEntry]) -> FileSearchManager {
+        let mgr = manager();
+        for f in files {
+            mgr.insert(f).unwrap();
+        }
+        mgr
+    }
+
+    #[test]
+    fn record_open_creates_row_on_first_call() {
+        let mgr = inserted_mgr_with(&[entry("f:1", "a.md", "/a.md", "md", 100)]);
+        mgr.record_open("/a.md").unwrap();
+        let opens: i32 = mgr
+            .db
+            .query_map(
+                "SELECT open_count FROM file_opens WHERE path = ?",
+                &[&"/a.md"],
+                |r| r.get(0),
+            )
+            .unwrap()[0];
+        assert_eq!(opens, 1);
+    }
+
+    #[test]
+    fn record_open_increments_count_on_subsequent_calls() {
+        let mgr = inserted_mgr_with(&[entry("f:1", "a.md", "/a.md", "md", 100)]);
+        mgr.record_open("/a.md").unwrap();
+        mgr.record_open("/a.md").unwrap();
+        mgr.record_open("/a.md").unwrap();
+        let opens: i32 = mgr
+            .db
+            .query_map(
+                "SELECT open_count FROM file_opens WHERE path = ?",
+                &[&"/a.md"],
+                |r| r.get(0),
+            )
+            .unwrap()[0];
+        assert_eq!(opens, 3);
+    }
+
+    #[test]
+    fn record_open_stamps_last_opened_to_roughly_now() {
+        let mgr = inserted_mgr_with(&[entry("f:1", "a.md", "/a.md", "md", 100)]);
+        let before = Utc::now().timestamp();
+        mgr.record_open("/a.md").unwrap();
+        let after = Utc::now().timestamp();
+
+        let last: i64 = mgr
+            .db
+            .query_map(
+                "SELECT last_opened_at FROM file_opens WHERE path = ?",
+                &[&"/a.md"],
+                |r| r.get(0),
+            )
+            .unwrap()[0];
+        assert!(last >= before && last <= after);
+    }
+
+    #[test]
+    fn get_recent_opened_returns_empty_when_no_opens() {
+        let mgr = inserted_mgr_with(&[entry("f:1", "a.md", "/a.md", "md", 100)]);
+        assert!(mgr.get_recent_opened(10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn get_recent_opened_orders_by_last_opened_desc() {
+        // Three files opened in a deterministic order; recents come
+        // back newest-first. Uses manual sleeps to force distinct
+        // timestamps rather than relying on insertion order.
+        let mgr = inserted_mgr_with(&[
+            entry("f:1", "a.md", "/a.md", "md", 0),
+            entry("f:2", "b.md", "/b.md", "md", 0),
+            entry("f:3", "c.md", "/c.md", "md", 0),
+        ]);
+        mgr.record_open("/a.md").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        mgr.record_open("/b.md").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        mgr.record_open("/c.md").unwrap();
+
+        let recents = mgr.get_recent_opened(10).unwrap();
+        assert_eq!(recents.len(), 3);
+        assert_eq!(recents[0].0.id, "f:3", "newest open first");
+        assert_eq!(recents[2].0.id, "f:1", "oldest open last");
+    }
+
+    #[test]
+    fn get_recent_opened_respects_limit() {
+        let mgr = inserted_mgr_with(&[
+            entry("f:1", "a.md", "/a.md", "md", 0),
+            entry("f:2", "b.md", "/b.md", "md", 0),
+        ]);
+        mgr.record_open("/a.md").unwrap();
+        mgr.record_open("/b.md").unwrap();
+        assert_eq!(mgr.get_recent_opened(1).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn get_recent_opened_drops_files_missing_from_index() {
+        // If a file was opened then later removed from the index
+        // (deleted from disk, indexer re-run), it should drop out of
+        // recents rather than surfacing a phantom entry.
+        let mgr = inserted_mgr_with(&[entry("f:1", "a.md", "/a.md", "md", 0)]);
+        mgr.record_open("/a.md").unwrap();
+        mgr.record_open("/gone.md").unwrap(); // path not in files table
+
+        let recents = mgr.get_recent_opened(10).unwrap();
+        assert_eq!(recents.len(), 1);
+        assert_eq!(recents[0].0.path, "/a.md");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -185,6 +185,73 @@ fn system_commands_route_results(sub: SubQuery) -> Vec<SearchResult> {
         .collect()
 }
 
+/// WAT-304: build the empty-query default view — up to 5 recently-launched
+/// apps + up to 5 recently-opened files, interleaved by timestamp so the
+/// most recently touched item comes first regardless of kind. Returns an
+/// empty vec on a fresh install (no launches or opens yet); the UI then
+/// falls back to its quick-tips placeholder.
+fn recents_results(state: &State<AppState>) -> Vec<SearchResult> {
+    const PER_KIND: usize = 5;
+    const TOTAL_LIMIT: usize = 10;
+
+    // Collect (timestamp, result) pairs so the final sort is a single
+    // pass over both kinds.
+    let mut combined: Vec<(i64, SearchResult)> = Vec::with_capacity(PER_KIND * 2);
+
+    // Recent apps — filter to those actually launched (count > 0 AND
+    // timestamp present). Sort by last_launched desc and take top N.
+    {
+        let apps = state.indexed_apps.read().unwrap();
+        let mut launched: Vec<&AppEntry> = apps
+            .iter()
+            .filter(|a| a.launch_count > 0 && a.last_launched.is_some())
+            .collect();
+        launched.sort_by(|a, b| b.last_launched.cmp(&a.last_launched));
+        for app in launched.into_iter().take(PER_KIND) {
+            let ts = app.last_launched.unwrap_or(0);
+            combined.push((
+                ts,
+                SearchResult {
+                    id: app.id.clone(),
+                    name: app.name.clone(),
+                    description: "Recently launched".to_string(),
+                    icon: app.icon_cache_path.clone(),
+                    result_type: ResultType::Application,
+                    score: 10000,
+                    usage_bonus: 0.0,
+                    action: SearchAction::LaunchApp { path: app.path.clone() },
+                },
+            ));
+        }
+    }
+
+    // Recent files — already sorted in SQL.
+    if let Ok(files) = state.file_search.get_recent_opened(PER_KIND) {
+        for (file, ts) in files {
+            combined.push((
+                ts,
+                SearchResult {
+                    id: file.id,
+                    name: file.name,
+                    description: format!("Recently opened · {}", file.path),
+                    icon: Some("file".to_string()),
+                    result_type: ResultType::File,
+                    score: 10000,
+                    usage_bonus: 0.0,
+                    action: SearchAction::OpenFile { path: file.path },
+                },
+            ));
+        }
+    }
+
+    combined.sort_by(|a, b| b.0.cmp(&a.0));
+    combined
+        .into_iter()
+        .take(TOTAL_LIMIT)
+        .map(|(_, r)| r)
+        .collect()
+}
+
 fn clipboard_route_results(state: &State<AppState>, sub: SubQuery) -> Vec<SearchResult> {
     let entries = match sub {
         SubQuery::Listing => state.clipboard.get_history(),
@@ -218,7 +285,7 @@ fn search(query: String, state: State<AppState>) -> Vec<SearchResult> {
     }
 
     match classify_prefix_route(&query) {
-        Route::Empty => return vec![],
+        Route::Empty => return recents_results(&state),
         Route::Notes(sub) => return notes_route_results(&state, sub),
         Route::Files(sub) => return files_route_results(&state, sub),
         Route::Clipboard(sub) => return clipboard_route_results(&state, sub),
@@ -323,6 +390,10 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
             Ok(())
         }
         SearchAction::OpenFile { path } => {
+            // WAT-304: record open before invoking the OS so stats
+            // reflect user intent even if the OS-level open fails.
+            // Failure to record is non-fatal — the open proceeds.
+            let _ = state.file_search.record_open(&path);
             open::that(&path).map_err(|e| e.to_string())
         }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -452,12 +452,16 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
 }
 
 function App() {
-  const { loadSettings, reindexApps, settings, showSettings, setShowSettings, resizeWindow, scratchpadVisible, noteEditorVisible, loadReservedPrefixes } = useAppStore();
+  const { loadSettings, reindexApps, settings, showSettings, setShowSettings, resizeWindow, scratchpadVisible, noteEditorVisible, loadReservedPrefixes, setQuery } = useAppStore();
 
   useEffect(() => {
     loadSettings();
     reindexApps();
     loadReservedPrefixes();
+    // WAT-304: populate the empty-query recents carousel on first paint
+    // so the user doesn't have to type anything to see their recent apps
+    // and files. Fires the same code path as clearing an existing query.
+    setQuery('');
     resizeWindow(); // Set initial window size
 
     // Disable default context menu

--- a/src/components/ResultsList.tsx
+++ b/src/components/ResultsList.tsx
@@ -19,18 +19,31 @@ function EmptyState() {
 export function ResultsList() {
   const { results, selectedIndex, setSelectedIndex, executeSelected, query } = useAppStore();
 
-  // Show empty state when no query
-  if (!query.trim()) {
+  // WAT-304: on an empty query, the backend returns recents (up to 5
+  // apps + 5 files). Show them with a "Recents" header. When recents
+  // are empty too — fresh install, no history yet — fall back to the
+  // quick-tips EmptyState.
+  const queryEmpty = !query.trim();
+  if (queryEmpty && results.length === 0) {
     return <EmptyState />;
   }
 
-  // Show nothing while searching (will show results when ready)
+  // Non-empty query with no results — stay silent while the user is
+  // still typing; the last results render via the map below.
   if (results.length === 0) {
     return null;
   }
 
   return (
     <div className="border-t border-[var(--border)] max-h-[320px] overflow-y-auto">
+      {queryEmpty && (
+        <p
+          data-testid="recents-header"
+          className="px-4 py-1.5 text-[10px] uppercase tracking-wider text-gray-400 font-medium"
+        >
+          Recents
+        </p>
+      )}
       {results.map((result, index) => (
         <ResultItem
           key={result.id}

--- a/src/components/__tests__/ResultsList.test.tsx
+++ b/src/components/__tests__/ResultsList.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { invoke } from '@tauri-apps/api/core';
+import { ResultsList } from '../ResultsList';
+import { useAppStore } from '../../stores/app';
+import type { SearchResult } from '../../types';
+
+const mockInvoke = vi.mocked(invoke);
+
+function resetStore() {
+  useAppStore.setState({
+    query: '',
+    results: [],
+    selectedIndex: 0,
+    settings: null,
+    isLoading: false,
+    showSettings: false,
+    scratchpad: '',
+    scratchpadVisible: false,
+    currentNote: null,
+    noteEditorVisible: false,
+    startupWarnings: [],
+    reservedPrefixes: [],
+  });
+}
+
+function appResult(id: string, name: string): SearchResult {
+  return {
+    id,
+    name,
+    description: 'Recently launched',
+    icon: null,
+    result_type: 'application',
+    score: 10000,
+    action: { type: 'launch_app', path: `/bin/${name.toLowerCase()}` },
+  } as SearchResult;
+}
+
+describe('ResultsList — WAT-304 recents on empty query', () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockReset();
+    mockInvoke.mockImplementation(async () => undefined);
+  });
+
+  it('shows the quick-tips empty state when query and results are both empty', () => {
+    render(<ResultsList />);
+    expect(screen.getByText(/quick tips/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('recents-header')).not.toBeInTheDocument();
+  });
+
+  it('shows a "Recents" header above results when the query is empty but recents exist', () => {
+    useAppStore.setState({
+      query: '',
+      results: [appResult('app:chrome', 'Chrome'), appResult('app:vscode', 'VS Code')],
+    });
+    render(<ResultsList />);
+
+    expect(screen.getByTestId('recents-header')).toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+    expect(screen.getByText('VS Code')).toBeInTheDocument();
+    // Quick-tips empty state is NOT shown when recents are present.
+    expect(screen.queryByText(/quick tips/i)).not.toBeInTheDocument();
+  });
+
+  it('does not show the "Recents" header once the user starts typing', () => {
+    useAppStore.setState({
+      query: 'chr',
+      results: [appResult('app:chrome', 'Chrome')],
+    });
+    render(<ResultsList />);
+
+    expect(screen.queryByTestId('recents-header')).not.toBeInTheDocument();
+    expect(screen.getByText('Chrome')).toBeInTheDocument();
+  });
+});

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -70,12 +70,11 @@ export const useAppStore = create<AppState>((set, get) => ({
   setQuery: async (query: string) => {
     set({ query, selectedIndex: 0 });
 
-    if (!query.trim()) {
-      set({ results: [] });
-      get().resizeWindow();
-      return;
-    }
-
+    // WAT-304: empty queries are now meaningful — the backend returns a
+    // "Recents" view (recently-launched apps + recently-opened files).
+    // Drop the pre-WAT-304 short-circuit so the query='' path calls
+    // through. On a fresh install the backend returns []; the UI then
+    // renders the quick-tips placeholder as before.
     try {
       const results = await invoke<SearchResult[]>('search', { query });
       set({ results });


### PR DESCRIPTION
## Summary
Empty search now returns the user's 5 most-recently-launched apps + 5 most-recently-opened files, interleaved newest-first. Fresh installs still see the Quick Tips placeholder.

Closes #18.

## Backend
- Migration 003: `file_opens` table keyed by path. Same decoupled pattern as WAT-201's `app_launches` — reindex doesn't wipe history, and we don't have to persist every indexed file.
- `FileSearchManager::record_open` (upsert) + `get_recent_opened` (JOIN with `files`, sort by `last_opened_at DESC`).
- `execute_action::OpenFile` records the open before invoking the OS so stats reflect intent even if the OS-level open fails.
- New `recents_results` helper interleaves app + file recents by timestamp, returns top 10.
- `Route::Empty` now returns recents instead of `vec![]`.

## Frontend
- Dropped the `setQuery('')` short-circuit in the store so empty queries reach the backend.
- App mount fires `setQuery('')` once so the carousel shows on first paint without typing.
- `ResultsList` adds a tiny "Recents" header when `query === '' && results.length > 0`. Quick Tips remains the fallback when recents are empty.

## Test plan
- [x] `cargo test` — 290 passed (+10: 7 file_opens, 3 migration updates)
- [x] `npm test` — 53 passed (+3: empty+empty shows tips, empty+recents shows header, typing hides header)
- [x] `npm run build` — clean
- [ ] Manual:
  - [ ] Fresh install → empty Watson shows Quick Tips
  - [ ] Launch Chrome, open a file via Watson, reopen Watson → both appear in recents, newest first
  - [ ] Start typing → "Recents" header disappears, fuzzy results take over
  - [ ] Clear the query → recents return

## Notes
- Followup candidate: `dismiss_recent(path)` for users who want to prune a specific entry.
- Stats keyed by path; relocating an app resets its counters (documented in WAT-201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)