### PR TITLE
WAT-301: Text snippets with cross-platform paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A fast, cross-platform productivity launcher inspired by Alfred. Built with Taur
 | `cb <query>` | Search clipboard history |
 | `> <command>` | Run system command |
 | `>left` / `>right` / `>max` / `>center` | Window management (Windows only in v1) |
+| `;addr`, `;sig`, &hellip; | Snippets — type a trigger, paste the expansion into the focused app |
 | `12 * 37` | Inline arithmetic — `sqrt(144)`, `(1+2)^3`, etc. |
 | `30 C to F` | Unit conversion — temperature / length / weight |
 | `100 USD to EUR` | Currency conversion (offline, snapshotted rates) |

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -41,6 +41,11 @@ pub fn migrations() -> Migrations<'static> {
         // pinned entries get the cost of a DB row. Clear-history
         // preserves pins in memory and on disk.
         M::up(SCHEMA_V004),
+        // 005 — WAT-301 snippets / text expansion. User-defined
+        // keyword → expansion pairs that surface alongside other
+        // search items; executing a snippet copies its expansion to
+        // the clipboard and pastes into the prior-focused window.
+        M::up(SCHEMA_V005),
     ])
 }
 
@@ -141,6 +146,18 @@ CREATE TABLE IF NOT EXISTS clipboard_pins (
 CREATE INDEX IF NOT EXISTS idx_clipboard_pins_pinned_at ON clipboard_pins(pinned_at);
 "#;
 
+const SCHEMA_V005: &str = r#"
+CREATE TABLE IF NOT EXISTS snippets (
+    id TEXT PRIMARY KEY,
+    trigger TEXT NOT NULL,
+    name TEXT NOT NULL,
+    expansion TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    modified_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_snippets_trigger ON snippets(trigger);
+"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,7 +181,7 @@ mod tests {
             .unwrap();
         // Bump this expectation whenever a new migration is appended
         // to `migrations()`.
-        assert_eq!(version, 4);
+        assert_eq!(version, 5);
     }
 
     #[test]
@@ -176,7 +193,7 @@ mod tests {
         let version: i32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 4);
+        assert_eq!(version, 5);
     }
 
     #[test]
@@ -198,7 +215,7 @@ mod tests {
         let post: i32 = conn
             .query_row("PRAGMA user_version", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(post, 4);
+        assert_eq!(post, 5);
     }
 
     #[test]
@@ -216,6 +233,7 @@ mod tests {
             "app_launches",
             "file_opens",
             "clipboard_pins",
+            "snippets",
         ] {
             let exists: i64 = conn
                 .query_row(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod indexers;
 mod notes;
 mod scratchpad;
 mod search;
+mod snippets;
 mod warnings;
 
 use actions::system::{execute_command, get_system_commands};
@@ -17,6 +18,7 @@ use config::settings::Settings;
 use files::{FileEntry, FileSearchManager, indexer::FileIndexer};
 use notes::NotesManager;
 use scratchpad::ScratchpadManager;
+use snippets::SnippetsManager;
 use warnings::{StartupWarning, StartupWarnings};
 use db::{AppEntry, Database};
 use indexers::{get_indexer, AppIndexer};
@@ -42,6 +44,9 @@ struct AppState {
     scratchpad: ScratchpadManager,
     notes: NotesManager,
     file_search: Arc<FileSearchManager>,
+    /// WAT-301: user-defined text snippets. Surface in search; on
+    /// execute, copy expansion and paste into the prior-focused window.
+    snippets: SnippetsManager,
     /// WAT-105: non-fatal conditions that surfaced during `setup()` and
     /// should be rendered in the UI — e.g., the global hotkey couldn't be
     /// registered because another app already owns it.
@@ -160,6 +165,19 @@ fn calculation_result(calc: calculator::Calculation) -> SearchResult {
         usage_bonus: 0.0,
         pinned: false,
         action: SearchAction::CopyClipboard { content: copy_value },
+    }
+}
+
+/// WAT-301: first-line preview of a snippet's expansion for the
+/// description row. Collapses multi-line expansions into a single
+/// line and truncates with an ellipsis so long snippets still fit.
+fn snippet_preview(expansion: &str) -> String {
+    let first_line = expansion.lines().next().unwrap_or("");
+    let clipped: String = first_line.chars().take(80).collect();
+    if first_line.chars().count() > 80 || expansion.contains('\n') {
+        format!("{clipped}…")
+    } else {
+        clipped
     }
 }
 
@@ -346,6 +364,30 @@ fn search(query: String, state: State<AppState>) -> Vec<SearchResult> {
     // fuzzy match over apps + web searches only, so `sleep` (no prefix)
     // still surfaces a matching app but never a SystemCommand result.
 
+    // WAT-301: add snippets whose trigger/name matches the query. Runs
+    // as a regular search-pipeline contributor alongside apps and web —
+    // no special prefix. Users who want scoped lookup can use a
+    // `;`-prefixed trigger by convention.
+    if let Ok(snippets) = state.snippets.search(&query) {
+        for snippet in snippets {
+            items.push(SearchResult {
+                // Highlight the trigger so the user can see how they'd
+                // type next time without opening Settings.
+                id: snippet.id.clone(),
+                name: format!("{}  —  {}", snippet.trigger, snippet.name),
+                description: snippet_preview(&snippet.expansion),
+                icon: Some("snippet".to_string()),
+                result_type: ResultType::Snippet,
+                // Between web (10000) and apps (0) so snippets surface
+                // reliably when triggered but don't swamp app matches.
+                score: 8000,
+                usage_bonus: 0.0,
+                pinned: false,
+                action: SearchAction::PasteSnippet { expansion: snippet.expansion },
+            });
+        }
+    }
+
     // Add apps
     if !query.contains(' ') || items.is_empty() {
         // WAT-201: compute the usage bonus once for the whole loop; `now`
@@ -418,6 +460,67 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
             let _ = state.file_search.record_open(&path);
             open::that(&path).map_err(|e| e.to_string())
         }
+        SearchAction::PasteSnippet { expansion } => {
+            // WAT-301: two steps. (1) Put the expansion on the
+            // clipboard — this alone is useful even if step 2 fails.
+            // (2) Synthesize Ctrl/Cmd+V into the prior-focused window.
+            // The frontend hides Watson before calling us, so focus
+            // has returned to wherever the user was typing.
+            state.clipboard.copy_to_clipboard(&expansion)?;
+            paste_snippet_via_os()
+        }
+    }
+}
+
+/// WAT-301: platform shim for synthesizing a paste keystroke.
+/// Windows uses PowerShell SendKeys (same lever as WAT-302). macOS
+/// uses osascript System Events. Linux is best-effort via xdotool;
+/// if xdotool isn't installed, the expansion is still on the
+/// clipboard and the user can paste manually.
+#[cfg(target_os = "windows")]
+fn paste_snippet_via_os() -> Result<(), String> {
+    // A tiny start-sleep gives the previously-focused window time to
+    // fully regain focus after Watson hides. SendKeys fires Ctrl+V.
+    std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-WindowStyle",
+            "Hidden",
+            "-Command",
+            "Start-Sleep -Milliseconds 80; (New-Object -ComObject WScript.Shell).SendKeys('^v')",
+        ])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn paste_snippet_via_os() -> Result<(), String> {
+    std::process::Command::new("osascript")
+        .args([
+            "-e",
+            "delay 0.08",
+            "-e",
+            r#"tell application "System Events" to keystroke "v" using command down"#,
+        ])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn paste_snippet_via_os() -> Result<(), String> {
+    // Linux best-effort. `xdotool` is widely available but not
+    // guaranteed; if it's missing, the snippet is already on the
+    // clipboard so the user can paste manually (Ctrl+V).
+    match std::process::Command::new("xdotool")
+        .args(["key", "--clearmodifiers", "ctrl+v"])
+        .spawn()
+    {
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!(
+            "Could not synthesize paste (xdotool not found: {e}). The snippet is on your clipboard — press Ctrl+V manually."
+        )),
     }
 }
 
@@ -570,6 +673,39 @@ fn clear_file_index(state: State<AppState>) -> Result<(), String> {
     state.file_search.clear_all()
 }
 
+// --- WAT-301: snippet CRUD ---
+
+#[tauri::command]
+fn list_snippets(state: State<AppState>) -> Result<Vec<snippets::Snippet>, String> {
+    state.snippets.list()
+}
+
+#[tauri::command]
+fn create_snippet(
+    trigger: String,
+    name: String,
+    expansion: String,
+    state: State<AppState>,
+) -> Result<snippets::Snippet, String> {
+    state.snippets.create(&trigger, &name, &expansion)
+}
+
+#[tauri::command]
+fn update_snippet(
+    id: String,
+    trigger: String,
+    name: String,
+    expansion: String,
+    state: State<AppState>,
+) -> Result<snippets::Snippet, String> {
+    state.snippets.update(&id, &trigger, &name, &expansion)
+}
+
+#[tauri::command]
+fn delete_snippet(id: String, state: State<AppState>) -> Result<(), String> {
+    state.snippets.delete(&id)
+}
+
 /// WAT-105: frontend calls this on mount to render a banner for any
 /// non-fatal conditions that surfaced during app setup.
 #[tauri::command]
@@ -659,6 +795,7 @@ pub fn run() {
             scratchpad,
             notes,
             file_search,
+            snippets: SnippetsManager::new(Arc::clone(&db)),
             startup_warnings,
         })
         .setup(|app| {
@@ -751,6 +888,10 @@ pub fn run() {
             reindex_files,
             cancel_reindex_files,
             clear_file_index,
+            list_snippets,
+            create_snippet,
+            update_snippet,
+            delete_snippet,
             get_startup_warnings,
             dismiss_startup_warning,
             open_config_folder,

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -50,6 +50,10 @@ pub enum ResultType {
     /// WAT-203: inline calculation result (arithmetic, unit conversion,
     /// currency). The action is always `CopyClipboard { content: result }`.
     Calculation,
+    /// WAT-301: user-defined text snippet. The action is always
+    /// `PasteSnippet { expansion }` — copy to clipboard then synthesize
+    /// a paste into the prior-focused window.
+    Snippet,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -61,6 +65,9 @@ pub enum SearchAction {
     CopyClipboard { content: String },
     OpenNote { note_id: String },
     OpenFile { path: String },
+    /// WAT-301: copy `expansion` to the clipboard and synthesize a
+    /// paste into the prior-focused window.
+    PasteSnippet { expansion: String },
 }
 
 pub struct SearchEngine {

--- a/src-tauri/src/snippets/mod.rs
+++ b/src-tauri/src/snippets/mod.rs
@@ -1,0 +1,292 @@
+//! WAT-301: user-defined text snippets.
+//!
+//! A snippet is a `(trigger, name, expansion)` tuple. Triggers surface
+//! the snippet in the unified search pipeline; names are the
+//! human-readable label in the result row; expansions are the text
+//! pasted into the prior-focused window when the user hits Enter.
+//!
+//! ## Trigger matching
+//!
+//! `search(query)` matches queries against both the trigger AND the
+//! name, case-insensitively. Users conventionally start triggers with
+//! a semicolon (`;addr`, `;sig`) to avoid colliding with app names,
+//! but nothing here enforces that — the trigger is just a string.
+//!
+//! ## Keying
+//!
+//! Triggers are NOT unique on their own; a user can keep multiple
+//! snippets with overlapping triggers (e.g., two different `;sig`
+//! variants). The id is the primary key. This trades some "intuitive
+//! uniqueness" for simpler CRUD semantics — the UI can enforce
+//! uniqueness if we want it.
+
+use crate::db::Database;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snippet {
+    pub id: String,
+    /// What the user types to surface the snippet (e.g., `;addr`).
+    pub trigger: String,
+    /// Human-readable label shown in the result row.
+    pub name: String,
+    /// The text that gets pasted on activation.
+    pub expansion: String,
+    pub created_at: i64,
+    pub modified_at: i64,
+}
+
+pub struct SnippetsManager {
+    db: Arc<Database>,
+}
+
+impl SnippetsManager {
+    pub fn new(db: Arc<Database>) -> Self {
+        SnippetsManager { db }
+    }
+
+    pub fn create(&self, trigger: &str, name: &str, expansion: &str) -> Result<Snippet, String> {
+        let id = format!("snip:{}", Utc::now().timestamp_millis());
+        let now = Utc::now().timestamp();
+        self.db
+            .execute(
+                "INSERT INTO snippets (id, trigger, name, expansion, created_at, modified_at)
+                 VALUES (?, ?, ?, ?, ?, ?)",
+                &[&id, &trigger, &name, &expansion, &now, &now],
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(Snippet {
+            id,
+            trigger: trigger.to_string(),
+            name: name.to_string(),
+            expansion: expansion.to_string(),
+            created_at: now,
+            modified_at: now,
+        })
+    }
+
+    pub fn update(
+        &self,
+        id: &str,
+        trigger: &str,
+        name: &str,
+        expansion: &str,
+    ) -> Result<Snippet, String> {
+        let now = Utc::now().timestamp();
+        self.db
+            .execute(
+                "UPDATE snippets SET trigger = ?, name = ?, expansion = ?, modified_at = ? WHERE id = ?",
+                &[&trigger, &name, &expansion, &now, &id],
+            )
+            .map_err(|e| e.to_string())?;
+        // Read back the full row so the caller gets created_at too.
+        self.get(id)?
+            .ok_or_else(|| format!("snippet '{id}' not found after update"))
+    }
+
+    pub fn delete(&self, id: &str) -> Result<(), String> {
+        self.db
+            .execute("DELETE FROM snippets WHERE id = ?", &[&id])
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    pub fn get(&self, id: &str) -> Result<Option<Snippet>, String> {
+        let rows = self
+            .db
+            .query_map(
+                "SELECT id, trigger, name, expansion, created_at, modified_at
+                 FROM snippets WHERE id = ?",
+                &[&id],
+                row_to_snippet,
+            )
+            .map_err(|e| e.to_string())?;
+        Ok(rows.into_iter().next())
+    }
+
+    pub fn list(&self) -> Result<Vec<Snippet>, String> {
+        self.db
+            .query_map(
+                "SELECT id, trigger, name, expansion, created_at, modified_at
+                 FROM snippets ORDER BY LOWER(trigger) ASC",
+                &[],
+                row_to_snippet,
+            )
+            .map_err(|e| e.to_string())
+    }
+
+    /// Match snippets against a user's query. Returns any snippet whose
+    /// trigger OR name contains the query as a case-insensitive
+    /// substring. Ordering: exact trigger match first (so `;addr`
+    /// beats `;address`), then everything else by modified_at desc so
+    /// recent edits stay near the top.
+    pub fn search(&self, query: &str) -> Result<Vec<Snippet>, String> {
+        let needle = format!("%{}%", query.to_lowercase());
+        let exact = query.to_lowercase();
+        self.db
+            .query_map(
+                "SELECT id, trigger, name, expansion, created_at, modified_at
+                 FROM snippets
+                 WHERE LOWER(trigger) LIKE ? OR LOWER(name) LIKE ?
+                 ORDER BY (LOWER(trigger) = ?) DESC, modified_at DESC
+                 LIMIT 20",
+                &[&needle, &needle, &exact],
+                row_to_snippet,
+            )
+            .map_err(|e| e.to_string())
+    }
+}
+
+fn row_to_snippet(row: &rusqlite::Row<'_>) -> rusqlite::Result<Snippet> {
+    Ok(Snippet {
+        id: row.get(0)?,
+        trigger: row.get(1)?,
+        name: row.get(2)?,
+        expansion: row.get(3)?,
+        created_at: row.get(4)?,
+        modified_at: row.get(5)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mgr() -> SnippetsManager {
+        SnippetsManager::new(Arc::new(Database::in_memory().expect("in-memory db")))
+    }
+
+    /// Ids are derived from `timestamp_millis()`, so two creates in
+    /// the same millisecond collide on the PRIMARY KEY. This helper
+    /// ticks the clock forward. Production rapid-import is a known
+    /// sub-ms collision risk documented on the notes module.
+    fn advance_ms_clock() {
+        std::thread::sleep(std::time::Duration::from_millis(2));
+    }
+
+    // --- create / get / list ---
+
+    #[test]
+    fn create_persists_row_and_returns_populated_snippet() {
+        let m = mgr();
+        let s = m.create(";addr", "Home Address", "123 Main St").unwrap();
+        assert!(s.id.starts_with("snip:"));
+        assert_eq!(s.trigger, ";addr");
+        assert_eq!(s.name, "Home Address");
+        assert_eq!(s.expansion, "123 Main St");
+        assert_eq!(s.created_at, s.modified_at);
+
+        // Round-trip via get().
+        let fetched = m.get(&s.id).unwrap().unwrap();
+        assert_eq!(fetched.expansion, "123 Main St");
+    }
+
+    #[test]
+    fn get_returns_none_for_unknown_id() {
+        let m = mgr();
+        assert!(m.get("snip:nope").unwrap().is_none());
+    }
+
+    #[test]
+    fn list_orders_alphabetically_by_trigger_case_insensitive() {
+        let m = mgr();
+        m.create(";zeta", "z", "z").unwrap();
+        advance_ms_clock();
+        m.create(";Alpha", "a", "a").unwrap();
+        advance_ms_clock();
+        m.create(";mid", "m", "m").unwrap();
+
+        let all = m.list().unwrap();
+        let triggers: Vec<String> = all.iter().map(|s| s.trigger.clone()).collect();
+        assert_eq!(triggers, vec![";Alpha".to_string(), ";mid".to_string(), ";zeta".to_string()]);
+    }
+
+    // --- update ---
+
+    #[test]
+    fn update_modifies_fields_and_bumps_modified_at() {
+        let m = mgr();
+        let s = m.create("t1", "n1", "e1").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let updated = m.update(&s.id, "t2", "n2", "e2").unwrap();
+        assert_eq!(updated.trigger, "t2");
+        assert_eq!(updated.name, "n2");
+        assert_eq!(updated.expansion, "e2");
+        assert!(
+            updated.modified_at > s.modified_at,
+            "modified_at should advance; before={}, after={}",
+            s.modified_at,
+            updated.modified_at
+        );
+        assert_eq!(updated.created_at, s.created_at, "created_at must not change");
+    }
+
+    #[test]
+    fn update_fails_on_unknown_id() {
+        let m = mgr();
+        assert!(m.update("snip:nope", "t", "n", "e").is_err());
+    }
+
+    // --- delete ---
+
+    #[test]
+    fn delete_removes_the_row() {
+        let m = mgr();
+        let s = m.create("t", "n", "e").unwrap();
+        m.delete(&s.id).unwrap();
+        assert!(m.get(&s.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn delete_unknown_id_is_ok() {
+        // Delete is idempotent — don't error if the row already went
+        // away (concurrent UI interactions, refresh races).
+        let m = mgr();
+        assert!(m.delete("snip:nope").is_ok());
+    }
+
+    // --- search ---
+
+    #[test]
+    fn search_matches_trigger_substring_case_insensitively() {
+        let m = mgr();
+        m.create(";addr", "Addr", "...").unwrap();
+        advance_ms_clock();
+        m.create(";sig", "Sig", "...").unwrap();
+        let hits = m.search("ADDR").unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].trigger, ";addr");
+    }
+
+    #[test]
+    fn search_matches_name_substring() {
+        let m = mgr();
+        m.create("t1", "Home Address", "...").unwrap();
+        let hits = m.search("home").unwrap();
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn search_returns_empty_for_no_match() {
+        let m = mgr();
+        m.create("t", "n", "e").unwrap();
+        assert!(m.search("nothing-matches-this").unwrap().is_empty());
+    }
+
+    #[test]
+    fn search_orders_exact_trigger_match_ahead_of_prefix_match() {
+        let m = mgr();
+        m.create(";address", "Longer", "...").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        m.create(";addr", "Exact", "...").unwrap();
+
+        let hits = m.search(";addr").unwrap();
+        assert_eq!(hits.len(), 2);
+        // Exact match for ";addr" must come first even though the other
+        // was created first (more recent modified_at doesn't override
+        // the exact-trigger bonus).
+        assert_eq!(hits[0].trigger, ";addr");
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { ResultsList } from './components/ResultsList';
 import { Scratchpad } from './components/Scratchpad';
 import { NoteEditor } from './components/NoteEditor';
 import { StartupWarningBanner } from './components/StartupWarningBanner';
+import { SnippetsSettings } from './components/SnippetsSettings';
 import { useAppStore } from './stores/app';
 import type { WebSearch } from './types';
 
@@ -383,6 +384,10 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
             </div>
           )}
         </div>
+
+        {/* WAT-301: snippets CRUD lives in its own component to keep
+            this file readable. */}
+        <SnippetsSettings />
 
         {/* WAT-303: clipboard privacy filter */}
         <div>

--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -115,6 +115,19 @@ function FileIcon() {
   );
 }
 
+function SnippetIcon() {
+  return (
+    <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-violet-400 to-violet-600 flex items-center justify-center">
+      <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="8" y1="13" x2="16" y2="13" />
+        <line x1="8" y1="17" x2="16" y2="17" />
+      </svg>
+    </div>
+  );
+}
+
 function CalculatorIcon() {
   return (
     <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-rose-400 to-pink-600 flex items-center justify-center">
@@ -163,6 +176,8 @@ export function ResultItem({ result, isSelected, onClick, index }: ResultItemPro
         return <FileIcon />;
       case 'calculation':
         return <CalculatorIcon />;
+      case 'snippet':
+        return <SnippetIcon />;
       default:
         return <DefaultIcon />;
     }
@@ -184,6 +199,8 @@ export function ResultItem({ result, isSelected, onClick, index }: ResultItemPro
         return 'File';
       case 'calculation':
         return 'Calc';
+      case 'snippet':
+        return 'Snip';
       default:
         return '';
     }

--- a/src/components/SnippetsSettings.tsx
+++ b/src/components/SnippetsSettings.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import type { Snippet } from '../types';
+
+/**
+ * WAT-301: Settings section for managing text snippets.
+ *
+ * Minimalist CRUD UI: list of (trigger, name) rows with edit/delete;
+ * a single inline editor for creating new entries or editing existing
+ * ones. Keeps the Settings panel uncluttered — users typically have a
+ * handful of snippets at most.
+ */
+export function SnippetsSettings() {
+  const [snippets, setSnippets] = useState<Snippet[]>([]);
+  const [editing, setEditing] = useState<Snippet | null>(null);
+  const [isAdding, setIsAdding] = useState(false);
+
+  const refresh = async () => {
+    try {
+      const list = await invoke<Snippet[]>('list_snippets');
+      setSnippets(list);
+    } catch (e) {
+      console.error('Failed to list snippets:', e);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleSave = async (data: { trigger: string; name: string; expansion: string }) => {
+    try {
+      if (editing) {
+        await invoke<Snippet>('update_snippet', {
+          id: editing.id,
+          trigger: data.trigger,
+          name: data.name,
+          expansion: data.expansion,
+        });
+      } else {
+        await invoke<Snippet>('create_snippet', data);
+      }
+      setEditing(null);
+      setIsAdding(false);
+      await refresh();
+    } catch (e) {
+      console.error('Failed to save snippet:', e);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    try {
+      await invoke('delete_snippet', { id });
+      setEditing(null);
+      await refresh();
+    } catch (e) {
+      console.error('Failed to delete snippet:', e);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-2">
+        <label className="text-sm text-gray-500">Snippets</label>
+        {!isAdding && editing === null && (
+          <button
+            type="button"
+            onClick={() => setIsAdding(true)}
+            className="text-xs text-blue-500 hover:text-blue-600"
+          >
+            + Add New
+          </button>
+        )}
+      </div>
+      <p className="text-xs text-gray-400 mb-2">
+        Type your trigger to paste the expansion into whatever app was focused before Watson.
+        Convention: prefix triggers with <span className="font-mono text-blue-400">;</span> to
+        avoid colliding with app names.
+      </p>
+
+      <div className="space-y-2">
+        {isAdding && (
+          <SnippetEditor
+            snippet={null}
+            onSave={handleSave}
+            onCancel={() => setIsAdding(false)}
+          />
+        )}
+
+        {snippets.map((s) =>
+          editing?.id === s.id ? (
+            <SnippetEditor
+              key={s.id}
+              snippet={s}
+              onSave={handleSave}
+              onCancel={() => setEditing(null)}
+              onDelete={() => handleDelete(s.id)}
+            />
+          ) : (
+            <div
+              key={s.id}
+              onClick={() => !isAdding && setEditing(s)}
+              className="flex items-center justify-between p-2 bg-[var(--input-bg)] rounded-lg cursor-pointer hover:bg-[var(--selected)] transition-colors"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-xs font-mono text-blue-400 shrink-0">{s.trigger}</span>
+                <span className="text-sm truncate">{s.name}</span>
+              </div>
+              <svg
+                className="w-4 h-4 text-gray-400 shrink-0"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path d="M9 18l6-6-6-6" />
+              </svg>
+            </div>
+          ),
+        )}
+
+        {snippets.length === 0 && !isAdding && (
+          <p className="text-xs text-gray-400 italic">No snippets yet &mdash; add one to get started.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface SnippetEditorProps {
+  snippet: Snippet | null;
+  onSave: (data: { trigger: string; name: string; expansion: string }) => void;
+  onCancel: () => void;
+  onDelete?: () => void;
+}
+
+function SnippetEditor({ snippet, onSave, onCancel, onDelete }: SnippetEditorProps) {
+  const [trigger, setTrigger] = useState(snippet?.trigger ?? '');
+  const [name, setName] = useState(snippet?.name ?? '');
+  const [expansion, setExpansion] = useState(snippet?.expansion ?? '');
+
+  const isValid = trigger.trim() && name.trim() && expansion.length > 0;
+
+  return (
+    <div className="space-y-2 p-3 bg-[var(--input-bg)] rounded-lg">
+      <div>
+        <label className="text-xs text-gray-500 mb-1 block">Trigger</label>
+        <input
+          type="text"
+          value={trigger}
+          onChange={(e) => setTrigger(e.target.value)}
+          placeholder=";addr"
+          className="w-full px-3 py-1.5 text-sm font-mono bg-[var(--background)] border border-[var(--border)] rounded-lg outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+      <div>
+        <label className="text-xs text-gray-500 mb-1 block">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Home Address"
+          className="w-full px-3 py-1.5 text-sm bg-[var(--background)] border border-[var(--border)] rounded-lg outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+      <div>
+        <label className="text-xs text-gray-500 mb-1 block">Expansion</label>
+        <textarea
+          value={expansion}
+          onChange={(e) => setExpansion(e.target.value)}
+          placeholder="The text that gets pasted&#10;(multi-line is fine)"
+          className="w-full h-20 px-3 py-1.5 text-sm bg-[var(--background)] border border-[var(--border)] rounded-lg resize-y outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </div>
+      <div className="flex gap-2 pt-1">
+        <button
+          type="button"
+          onClick={() => isValid && onSave({ trigger, name, expansion })}
+          disabled={!isValid}
+          className="px-3 py-1.5 text-sm bg-blue-500 text-white rounded-lg hover:bg-blue-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="px-3 py-1.5 text-sm bg-[var(--selected)] rounded-lg hover:bg-[var(--border)] transition-colors"
+        >
+          Cancel
+        </button>
+        {onDelete && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="px-3 py-1.5 text-sm text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors ml-auto"
+          >
+            Delete
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/SnippetsSettings.test.tsx
+++ b/src/components/__tests__/SnippetsSettings.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { invoke } from '@tauri-apps/api/core';
+import { SnippetsSettings } from '../SnippetsSettings';
+import type { Snippet } from '../../types';
+
+const mockInvoke = vi.mocked(invoke);
+
+function snippet(overrides: Partial<Snippet> = {}): Snippet {
+  return {
+    id: overrides.id ?? 'snip:1',
+    trigger: overrides.trigger ?? ';addr',
+    name: overrides.name ?? 'Home Address',
+    expansion: overrides.expansion ?? '123 Main St',
+    created_at: overrides.created_at ?? 1_700_000_000,
+    modified_at: overrides.modified_at ?? 1_700_000_000,
+  };
+}
+
+describe('SnippetsSettings — WAT-301 CRUD', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'list_snippets') return [] as Snippet[];
+      return undefined;
+    });
+  });
+
+  it('shows an empty-state when no snippets exist', async () => {
+    render(<SnippetsSettings />);
+    // list_snippets is invoked on mount.
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('list_snippets');
+    });
+    expect(await screen.findByText(/no snippets yet/i)).toBeInTheDocument();
+  });
+
+  it('renders existing snippets in the list', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'list_snippets') return [snippet({ id: 'snip:1', trigger: ';addr', name: 'Home' })];
+      return undefined;
+    });
+
+    render(<SnippetsSettings />);
+
+    expect(await screen.findByText(';addr')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('clicking "Add New" shows an editor and creating invokes create_snippet', async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'list_snippets') return [] as Snippet[];
+      if (cmd === 'create_snippet') return snippet();
+      return undefined;
+    });
+    render(<SnippetsSettings />);
+
+    await screen.findByText(/no snippets yet/i);
+    await user.click(screen.getByRole('button', { name: /add new/i }));
+
+    // Fill the form.
+    await user.type(screen.getByPlaceholderText(';addr'), ';hello');
+    await user.type(screen.getByPlaceholderText('Home Address'), 'Hello');
+    await user.type(screen.getByPlaceholderText(/pasted/i), 'Hi there');
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    const createCall = mockInvoke.mock.calls.find((c) => c[0] === 'create_snippet');
+    expect(createCall, 'create_snippet should be invoked').toBeDefined();
+    expect(createCall?.[1]).toEqual({
+      trigger: ';hello',
+      name: 'Hello',
+      expansion: 'Hi there',
+    });
+  });
+
+  it('Save is disabled when required fields are empty', async () => {
+    const user = userEvent.setup();
+    render(<SnippetsSettings />);
+    await screen.findByText(/no snippets yet/i);
+    await user.click(screen.getByRole('button', { name: /add new/i }));
+
+    const save = screen.getByRole('button', { name: /^save$/i });
+    expect(save).toBeDisabled();
+
+    // Fill only one field — still disabled.
+    await user.type(screen.getByPlaceholderText(';addr'), ';x');
+    expect(save).toBeDisabled();
+  });
+
+  it('clicking an existing row opens the editor with its values prefilled', async () => {
+    const existing = snippet({ id: 'snip:1', trigger: ';sig', name: 'Signature', expansion: '--\nWill' });
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'list_snippets') return [existing];
+      return undefined;
+    });
+    const user = userEvent.setup();
+    render(<SnippetsSettings />);
+
+    await screen.findByText(';sig');
+    await user.click(screen.getByText(';sig'));
+
+    // Inputs prefilled.
+    expect(screen.getByDisplayValue(';sig')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Signature')).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/Will/)).toBeInTheDocument();
+    // Delete button is visible only when editing an existing snippet.
+    expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+  });
+
+  it('delete invokes delete_snippet with the id', async () => {
+    const existing = snippet({ id: 'snip:42' });
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'list_snippets') return [existing];
+      return undefined;
+    });
+    const user = userEvent.setup();
+    render(<SnippetsSettings />);
+
+    await screen.findByText(';addr');
+    await user.click(screen.getByText(';addr'));
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+
+    expect(mockInvoke).toHaveBeenCalledWith('delete_snippet', { id: 'snip:42' });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface SearchResult {
   name: string;
   description: string;
   icon: string | null;
-  result_type: 'application' | 'web_search' | 'system_command' | 'clipboard' | 'note' | 'file' | 'calculation';
+  result_type: 'application' | 'web_search' | 'system_command' | 'clipboard' | 'note' | 'file' | 'calculation' | 'snippet';
   score: number;
   /** WAT-303: populated only for clipboard results; true when pinned. */
   pinned?: boolean;
@@ -16,7 +16,17 @@ export type SearchAction =
   | { type: 'run_command'; command: string }
   | { type: 'copy_clipboard'; content: string }
   | { type: 'open_note'; note_id: string }
-  | { type: 'open_file'; path: string };
+  | { type: 'open_file'; path: string }
+  | { type: 'paste_snippet'; expansion: string };
+
+export interface Snippet {
+  id: string;
+  trigger: string;
+  name: string;
+  expansion: string;
+  created_at: number;
+  modified_at: number;
+}
 
 export interface Settings {
   general: GeneralSettings;


### PR DESCRIPTION
## Summary
Define snippets once (`;addr` → "123 Main St", `;sig` → email signature, etc.), then trigger them by typing the trigger into Watson. On Enter, Watson copies the expansion to the clipboard AND synthesizes a Ctrl/Cmd+V into whatever app had focus before Watson came up.

Closes #15. Last of Sprint 3.

## What ships

- **Data**: migration 005, `snippets` table, full CRUD via `SnippetsManager`.
- **Search**: new `ResultType::Snippet` + `SearchAction::PasteSnippet`. Snippets surface in the unified search pipeline alongside apps and web. Exact-trigger matches sort ahead of longer-prefix matches even when the longer one was edited more recently.
- **Paste mechanics**: per-platform shim. Windows uses PowerShell SendKeys `^v` (same lever as WAT-302). macOS uses `osascript` System Events. Linux is best-effort via `xdotool`; if it's missing, the snippet is on the clipboard and the user gets a clear message to paste manually.
- **Settle delay**: 80ms before synthesizing the keystroke. Watson hides before `execute_action` runs, but window-focus propagation takes a few frames on all three OSes.
- **Settings UI**: `SnippetsSettings` component with list + inline editor (Trigger, Name, Expansion). Save disabled until all fields filled; Delete visible only when editing existing.

## Test plan
- [x] `cargo test` — 325 passed (+11 in `snippets` module)
- [x] `npm test` — 64 passed (+6 in SnippetsSettings)
- [x] `npm run build` — clean
- [ ] Manual:
  - [ ] Settings → Snippets → Add New → trigger `;addr`, name "Home", expansion "123 Main St" → Save
  - [ ] Alt+Space → type `;addr` → Enter → verify "123 Main St" pasted into the previously-focused app
  - [ ] Edit → change expansion → Save → trigger again → new expansion pastes
  - [ ] Delete → snippet disappears from both list and search

## Design notes
- Triggers aren't unique per-row (two snippets can share a trigger if the user wants). Keeps CRUD simple; if uniqueness becomes a UX need, the UI can enforce it.
- Snippet score is 8000 — between web (10000) and apps (0) so a triggered snippet surfaces reliably without swamping ordinary app matches.
- Multi-line expansions get a single-line preview in the result description (first line, ellipsized).
- Score ordering protects against a `;addr` snippet being lost behind an app with "addr" in its name; the dedicated trigger mechanism is the right way to reach snippets.

## Followup
- Sub-ms id collision during rapid bulk import (e.g., config migration). Known and documented in the notes module; same pattern here. Low-risk for interactive users.
- `enigo` would give us proper typed-out expansion without clobbering the user's clipboard. That's a bigger dependency; the clipboard+paste pattern is the pragmatic v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)