### PR TITLE
WAT-407: Responsive window width + re-center on show

### DIFF
--- a/src-tauri/src/layout.rs
+++ b/src-tauri/src/layout.rs
@@ -1,0 +1,126 @@
+//! WAT-407: window layout math — breakpoints for width-scaling on
+//! ultrawide monitors, and horizontal centering on a monitor.
+//!
+//! Separated from `lib.rs::resize_window` / `show_window` so the
+//! breakpoint math is testable in isolation — the Tauri-side calls
+//! that read monitor dimensions and push `set_size` / `set_position`
+//! stay thin adapters around these pure functions.
+
+/// Width Watson uses on ordinary (sub-1600px) displays — the pre-WAT-407
+/// baseline. Exposed as a constant so tests and consumers can reference
+/// the default without magic numbers.
+pub const DEFAULT_WIDTH: u32 = 600;
+
+/// Viewport threshold above which Watson widens from 600 → 700. Using
+/// `>` (strict) rather than `>=` so "exactly 1600px" monitors keep the
+/// default width — conservative bias toward "don't surprise existing
+/// users."
+pub const MID_BREAKPOINT: f64 = 1600.0;
+
+/// Viewport threshold above which Watson widens from 700 → 800.
+pub const LARGE_BREAKPOINT: f64 = 2400.0;
+
+/// Pick the window width for a monitor with the given logical width.
+///
+/// ```text
+/// monitor_logical_width ≤ 1600 → 600  (default)
+/// 1600 < width ≤ 2400           → 700  (mid)
+/// width > 2400                  → 800  (ultrawide / 4K)
+/// ```
+pub fn compute_window_width(monitor_logical_width: f64) -> u32 {
+    if monitor_logical_width > LARGE_BREAKPOINT {
+        800
+    } else if monitor_logical_width > MID_BREAKPOINT {
+        700
+    } else {
+        DEFAULT_WIDTH
+    }
+}
+
+/// Compute the x-coordinate that horizontally centers a window of
+/// `window_width` on a monitor whose left edge is at `monitor_x` and
+/// whose width is `monitor_width`. All values in logical pixels.
+///
+/// Secondary-monitor safe: a non-zero `monitor_x` carries through, so
+/// centering on a display at (1920, 0) with width 1920 and a 600px
+/// window yields `1920 + (1920 - 600) / 2 = 2580`, not `660`.
+pub fn center_x_on_monitor(monitor_x: f64, monitor_width: f64, window_width: u32) -> f64 {
+    monitor_x + (monitor_width - window_width as f64) / 2.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- compute_window_width ---
+
+    #[test]
+    fn default_width_on_sub_mid_monitor() {
+        assert_eq!(compute_window_width(1024.0), 600);
+        assert_eq!(compute_window_width(1366.0), 600);
+        assert_eq!(compute_window_width(1440.0), 600);
+    }
+
+    #[test]
+    fn exactly_mid_breakpoint_stays_default() {
+        // `>` comparison — exactly 1600 keeps the baseline. Pin the
+        // boundary behavior so a `>=` regression would be caught.
+        assert_eq!(compute_window_width(1600.0), 600);
+    }
+
+    #[test]
+    fn mid_width_for_viewports_above_mid_breakpoint() {
+        assert_eq!(compute_window_width(1601.0), 700);
+        assert_eq!(compute_window_width(1920.0), 700);
+        assert_eq!(compute_window_width(2048.0), 700);
+        assert_eq!(compute_window_width(2400.0), 700);
+    }
+
+    #[test]
+    fn large_width_for_viewports_above_large_breakpoint() {
+        assert_eq!(compute_window_width(2401.0), 800);
+        assert_eq!(compute_window_width(3440.0), 800); // Common ultrawide
+        assert_eq!(compute_window_width(3840.0), 800); // 4K
+        assert_eq!(compute_window_width(5120.0), 800); // 5K
+    }
+
+    #[test]
+    fn edge_case_zero_width_is_default() {
+        // Defensive: a zero-width monitor is nonsense but shouldn't
+        // return a weird value. Falls into the "≤ mid" branch.
+        assert_eq!(compute_window_width(0.0), DEFAULT_WIDTH);
+    }
+
+    // --- center_x_on_monitor ---
+
+    #[test]
+    fn centers_on_primary_monitor() {
+        // 600px window on a 1920-wide primary monitor:
+        //   x = 0 + (1920 - 600) / 2 = 660
+        assert_eq!(center_x_on_monitor(0.0, 1920.0, 600), 660.0);
+    }
+
+    #[test]
+    fn centers_on_secondary_monitor_with_offset() {
+        // Secondary at x=1920, width=2560, window=800:
+        //   x = 1920 + (2560 - 800) / 2 = 2800
+        assert_eq!(center_x_on_monitor(1920.0, 2560.0, 800), 2800.0);
+    }
+
+    #[test]
+    fn centers_ultrawide_window_on_ultrawide_monitor() {
+        // Window of 800 on a 3440-wide ultrawide:
+        //   x = 0 + (3440 - 800) / 2 = 1320
+        assert_eq!(center_x_on_monitor(0.0, 3440.0, 800), 1320.0);
+    }
+
+    #[test]
+    fn handles_fractional_monitor_widths() {
+        // Some HiDPI displays report fractional logical widths (e.g.
+        // 1792.5 on a 16" MBP @ 2x). Centering still returns a sensible
+        // float.
+        let x = center_x_on_monitor(0.0, 1792.5, 700);
+        // (1792.5 - 700) / 2 = 546.25
+        assert!((x - 546.25).abs() < 1e-9);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod config;
 mod db;
 mod files;
 mod indexers;
+mod layout;
 mod notes;
 mod scratchpad;
 mod search;
@@ -533,12 +534,65 @@ fn hide_window(window: tauri::WebviewWindow) {
 fn show_window(window: tauri::WebviewWindow) {
     window.show().ok();
     window.set_focus().ok();
+    // WAT-407: re-center on show so the window lands on the middle
+    // of whichever monitor it will appear on (useful after a
+    // disconnect/reconnect that leaves it offscreen).
+    center_window_on_current_monitor(&window);
 }
 
 #[tauri::command]
 fn resize_window(window: tauri::WebviewWindow, height: u32) {
     use tauri::LogicalSize;
-    let _ = window.set_size(LogicalSize::new(600, height));
+    // WAT-407: scale width to monitor so Watson doesn't look tiny on
+    // ultrawide / 4K displays. Falls back to 600 (the pre-WAT-407
+    // default) when monitor info isn't available.
+    let width = window_width_for_current_monitor(&window);
+    let _ = window.set_size(LogicalSize::new(width, height));
+}
+
+/// WAT-407: look up the monitor the window is currently on, convert
+/// its physical size to logical pixels, and pick the Watson width
+/// from the breakpoints table. Defaults to 600 if the OS can't
+/// report a monitor (rare — unplugged display mid-hotkey).
+fn window_width_for_current_monitor(window: &tauri::WebviewWindow) -> u32 {
+    let Ok(Some(monitor)) = window.current_monitor() else {
+        return layout::DEFAULT_WIDTH;
+    };
+    let scale = monitor.scale_factor();
+    // Avoid divide-by-zero on pathological scale factors.
+    if scale <= 0.0 {
+        return layout::DEFAULT_WIDTH;
+    }
+    let logical_width = monitor.size().width as f64 / scale;
+    layout::compute_window_width(logical_width)
+}
+
+/// WAT-407: center horizontally on the current monitor, preserving
+/// the window's current Y. Called from `show_window` so a re-showing
+/// window always lands within a sensible display rather than
+/// lingering offscreen after a monitor change.
+fn center_window_on_current_monitor(window: &tauri::WebviewWindow) {
+    use tauri::LogicalPosition;
+    let Ok(Some(monitor)) = window.current_monitor() else {
+        return;
+    };
+    let scale = monitor.scale_factor();
+    if scale <= 0.0 {
+        return;
+    }
+    let mon_size = monitor.size();
+    let mon_pos = monitor.position();
+    let mon_logical_width = mon_size.width as f64 / scale;
+    let mon_logical_x = mon_pos.x as f64 / scale;
+    let width = window_width_for_current_monitor(window);
+    let center_x = layout::center_x_on_monitor(mon_logical_x, mon_logical_width, width);
+    // Preserve Y so we don't fight the user's vertical choice. Falls
+    // back to the monitor's y origin if outer_position fails.
+    let current_y = match window.outer_position() {
+        Ok(p) => p.y as f64 / scale,
+        Err(_) => mon_pos.y as f64 / scale,
+    };
+    let _ = window.set_position(LogicalPosition::new(center_x, current_y));
 }
 
 #[tauri::command]
@@ -820,6 +874,10 @@ pub fn run() {
                     } else {
                         hotkey_window.show().ok();
                         hotkey_window.set_focus().ok();
+                        // WAT-407: recenter so the launcher reliably
+                        // appears mid-screen on whatever monitor the
+                        // user is currently looking at.
+                        center_window_on_current_monitor(&hotkey_window);
                     }
                 }
             }) {


### PR DESCRIPTION
## Summary
The launcher used a hardcoded 600px width regardless of monitor size — postage-stamp-sized on ultrawide and 4K. Now the width scales with the monitor the launcher appears on.

Closes #27.

## Breakpoints
| monitor logical width | window width |
|---|---|
| ≤ 1600 | 600 (unchanged default) |
| 1600 < w ≤ 2400 | 700 |
| > 2400 | 800 |

Strict `>` comparisons — a monitor exactly 1600px wide keeps the baseline so no existing user is surprised.

## Centering
`show_window` and the global-hotkey handler both re-center horizontally after showing. Y is preserved (don't fight the user's drag choice). Height changes from result churn do NOT trigger re-centering, only explicit show does — no jitter.

## Implementation
New `src-tauri/src/layout.rs` holds the pure math (`compute_window_width`, `center_x_on_monitor`). Tauri-side adapters read the current monitor, convert physical → logical pixels, and apply.

## Test plan
- [x] `cargo test` — 334 passed (+9 new in `layout`, covering both breakpoints including exact-boundary pinning, zero-width defensive, HiDPI fractional widths, secondary-monitor offset)
- [x] `npm test` — 64 passed (no frontend changes needed)
- [x] `npm run build` — clean
- [ ] Manual:
  - [ ] 1080p display → width stays 600
  - [ ] 1440p display (2560×1440) → width 700, centered
  - [ ] 4K display → width 800, centered
  - [ ] Ultrawide 3440×1440 → width 800, centered
  - [ ] Second monitor → hotkey from primary shows on primary; move cursor to secondary, hotkey again → shows centered on secondary (Tauri follows cursor monitor)

## Notes
- The `>` (vs `>=`) choice makes mid-range users (exactly 1600) keep their current experience. If feedback says "my 1600×1200 feels small", we can flip to `>=`. Easy change, test-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)