### PR TITLE
WAT-405: Confirmation modals for destructive actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Scratchpad } from './components/Scratchpad';
 import { NoteEditor } from './components/NoteEditor';
 import { StartupWarningBanner } from './components/StartupWarningBanner';
 import { SnippetsSettings } from './components/SnippetsSettings';
+import { ConfirmModal } from './components/ConfirmModal';
 import { useAppStore } from './stores/app';
 import type { WebSearch } from './types';
 
@@ -172,6 +173,8 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
   const [version, setVersion] = useState('');
   const [updateStatus, setUpdateStatus] = useState<'idle' | 'checking' | 'available' | 'downloading' | 'ready' | 'none' | 'error'>('idle');
   const [updateError, setUpdateError] = useState('');
+  // WAT-405: confirm-modal state for Clear Clipboard History.
+  const [showClearClipboardConfirm, setShowClearClipboardConfirm] = useState(false);
 
   useEffect(() => {
     getVersion().then(setVersion).catch(() => setVersion('unknown'));
@@ -422,13 +425,7 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
               Re-index Applications
             </button>
             <button
-              onClick={async () => {
-                try {
-                  await invoke('clear_clipboard_history');
-                } catch (e) {
-                  console.error('Failed to clear clipboard:', e);
-                }
-              }}
+              onClick={() => setShowClearClipboardConfirm(true)}
               className="px-3 py-1.5 rounded-lg text-sm bg-[var(--input-bg)] hover:bg-[var(--selected)] transition-colors"
             >
               Clear Clipboard History
@@ -474,6 +471,23 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
           <p className="mt-2 text-gray-500">Watson v{version}</p>
         </div>
       </div>
+
+      <ConfirmModal
+        open={showClearClipboardConfirm}
+        title="Clear clipboard history?"
+        message="This removes all unpinned clipboard entries. Pinned entries are kept."
+        confirmLabel="Clear"
+        variant="danger"
+        onConfirm={async () => {
+          setShowClearClipboardConfirm(false);
+          try {
+            await invoke('clear_clipboard_history');
+          } catch (e) {
+            console.error('Failed to clear clipboard:', e);
+          }
+        }}
+        onCancel={() => setShowClearClipboardConfirm(false)}
+      />
     </div>
   );
 }

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * WAT-405: reusable confirmation modal for destructive actions.
+ *
+ * Replaces native `window.confirm`, which fights Tauri window
+ * transparency/focus on Windows and feels out of place against the
+ * themed launcher UI. The modal is rendered as an in-app overlay with:
+ *
+ * - Focus trap: the cancel and confirm buttons are keyboard-tabbable
+ *   but focus can't escape to elements behind the overlay.
+ * - Escape → cancel.
+ * - Enter → confirm (fires the action).
+ * - `role="dialog"` + `aria-modal="true"` + `aria-labelledby` so
+ *   screen readers announce the modal and the action title.
+ * - `variant: 'danger'` tints the confirm button red for destructive
+ *   actions like Delete.
+ *
+ * Usage:
+ * ```tsx
+ * const [open, setOpen] = useState(false);
+ * <ConfirmModal
+ *   open={open}
+ *   title="Delete this note?"
+ *   message="This can't be undone."
+ *   confirmLabel="Delete"
+ *   variant="danger"
+ *   onConfirm={() => { doDelete(); setOpen(false); }}
+ *   onCancel={() => setOpen(false)}
+ * />
+ * ```
+ */
+export interface ConfirmModalProps {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** `primary` uses blue; `danger` uses red. Default `primary`. */
+  variant?: 'primary' | 'danger';
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'primary',
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Focus the confirm button when the modal opens — the user is
+  // there deliberately and Enter should fire the action. Tab cycles
+  // to cancel; Shift-Tab cycles back.
+  useEffect(() => {
+    if (open) {
+      confirmRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onCancel();
+    } else if (e.key === 'Enter') {
+      // Enter always confirms regardless of which button has focus —
+      // standard dialog behavior. If the user wanted cancel they'd
+      // Escape.
+      e.preventDefault();
+      onConfirm();
+    } else if (e.key === 'Tab') {
+      // Focus trap: cycle between our two buttons only. Without this
+      // the user's Tab could fall through into the launcher input
+      // behind the overlay.
+      const buttons = overlayRef.current?.querySelectorAll<HTMLButtonElement>('button');
+      if (!buttons || buttons.length === 0) return;
+      const first = buttons[0];
+      const last = buttons[buttons.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  };
+
+  const confirmColor =
+    variant === 'danger'
+      ? 'bg-red-500 hover:bg-red-600 text-white'
+      : 'bg-blue-500 hover:bg-blue-600 text-white';
+
+  return (
+    <div
+      ref={overlayRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-modal-title"
+      onKeyDown={handleKeyDown}
+      // Backdrop click cancels — matches every launcher convention.
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+    >
+      <div
+        className="max-w-sm mx-4 p-4 bg-[var(--background)] border border-[var(--border)] rounded-xl shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 id="confirm-modal-title" className="text-sm font-semibold mb-1">
+          {title}
+        </h3>
+        <p className="text-xs text-gray-500 mb-3">{message}</p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1.5 text-sm rounded-lg bg-[var(--input-bg)] hover:bg-[var(--selected)] transition-colors"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            onClick={onConfirm}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${confirmColor}`}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useAppStore } from '../stores/app';
 import { renderMarkdown } from '../lib/markdown';
+import { ConfirmModal } from './ConfirmModal';
 
 export function NoteEditor() {
   const { currentNote, createNote, updateNote, deleteNote, closeNoteEditor, reloadNoteFromDisk } =
@@ -13,6 +14,7 @@ export function NoteEditor() {
   // because preview mode is a viewing preference, not a persisted one —
   // reopening a note always starts in edit mode.
   const [isPreviewing, setIsPreviewing] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const titleRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLTextAreaElement>(null);
 
@@ -70,10 +72,16 @@ export function NoteEditor() {
     }
   };
 
-  const handleDelete = async () => {
+  const requestDelete = () => {
     if (currentNote) {
-      await deleteNote(currentNote.id);
+      setShowDeleteConfirm(true);
     }
+  };
+
+  const confirmDelete = async () => {
+    if (!currentNote) return;
+    setShowDeleteConfirm(false);
+    await deleteNote(currentNote.id);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -112,7 +120,7 @@ export function NoteEditor() {
           </button>
           {currentNote && (
             <button
-              onClick={handleDelete}
+              onClick={requestDelete}
               className="px-2 py-1 text-xs text-gray-500 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
             >
               Delete
@@ -213,6 +221,16 @@ export function NoteEditor() {
           </button>
         </div>
       </div>
+
+      <ConfirmModal
+        open={showDeleteConfirm}
+        title="Delete this note?"
+        message="This can't be undone — the note and its on-disk .md file will both be removed."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setShowDeleteConfirm(false)}
+      />
     </div>
   );
 }

--- a/src/components/SnippetsSettings.tsx
+++ b/src/components/SnippetsSettings.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import type { Snippet } from '../types';
+import { ConfirmModal } from './ConfirmModal';
 
 /**
  * WAT-301: Settings section for managing text snippets.
@@ -14,6 +15,9 @@ export function SnippetsSettings() {
   const [snippets, setSnippets] = useState<Snippet[]>([]);
   const [editing, setEditing] = useState<Snippet | null>(null);
   const [isAdding, setIsAdding] = useState(false);
+  // WAT-405: confirm before deleting a snippet so stray clicks don't
+  // wipe an expansion the user has been maintaining for weeks.
+  const [deletingSnippet, setDeletingSnippet] = useState<Snippet | null>(null);
 
   const refresh = async () => {
     try {
@@ -48,7 +52,14 @@ export function SnippetsSettings() {
     }
   };
 
-  const handleDelete = async (id: string) => {
+  const requestDelete = (snippet: Snippet) => {
+    setDeletingSnippet(snippet);
+  };
+
+  const confirmDelete = async () => {
+    if (!deletingSnippet) return;
+    const id = deletingSnippet.id;
+    setDeletingSnippet(null);
     try {
       await invoke('delete_snippet', { id });
       setEditing(null);
@@ -94,7 +105,7 @@ export function SnippetsSettings() {
               snippet={s}
               onSave={handleSave}
               onCancel={() => setEditing(null)}
-              onDelete={() => handleDelete(s.id)}
+              onDelete={() => requestDelete(s)}
             />
           ) : (
             <div
@@ -123,6 +134,20 @@ export function SnippetsSettings() {
           <p className="text-xs text-gray-400 italic">No snippets yet &mdash; add one to get started.</p>
         )}
       </div>
+
+      <ConfirmModal
+        open={deletingSnippet !== null}
+        title="Delete this snippet?"
+        message={
+          deletingSnippet
+            ? `"${deletingSnippet.trigger}" — ${deletingSnippet.name} — will be removed. This can't be undone.`
+            : ''
+        }
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={confirmDelete}
+        onCancel={() => setDeletingSnippet(null)}
+      />
     </div>
   );
 }

--- a/src/components/__tests__/ConfirmModal.test.tsx
+++ b/src/components/__tests__/ConfirmModal.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ConfirmModal } from '../ConfirmModal';
+
+function noop() {}
+
+describe('ConfirmModal (WAT-405)', () => {
+  it('renders nothing when open=false', () => {
+    render(
+      <ConfirmModal
+        open={false}
+        title="t"
+        message="m"
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders a labelled dialog when open=true', () => {
+    render(
+      <ConfirmModal
+        open
+        title="Delete this note?"
+        message="This can't be undone."
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'confirm-modal-title');
+    expect(screen.getByText('Delete this note?')).toBeInTheDocument();
+    expect(screen.getByText(/can't be undone/i)).toBeInTheDocument();
+  });
+
+  it('focuses the confirm button on open', () => {
+    render(
+      <ConfirmModal
+        open
+        title="t"
+        message="m"
+        confirmLabel="OK"
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'OK' })).toHaveFocus();
+  });
+
+  it('Enter fires onConfirm', async () => {
+    const onConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal
+        open
+        title="t"
+        message="m"
+        onConfirm={onConfirm}
+        onCancel={noop}
+      />,
+    );
+    await user.keyboard('{Enter}');
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape fires onCancel', async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal
+        open
+        title="t"
+        message="m"
+        onConfirm={noop}
+        onCancel={onCancel}
+      />,
+    );
+    await user.keyboard('{Escape}');
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking the backdrop cancels; clicking the panel does not', async () => {
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal
+        open
+        title="t"
+        message="m"
+        onConfirm={noop}
+        onCancel={onCancel}
+      />,
+    );
+    const dialog = screen.getByRole('dialog');
+    // Click directly on the dialog (overlay backdrop) — e.target === e.currentTarget.
+    await user.click(dialog);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    // Clicking inside the inner panel (title) should NOT trigger cancel.
+    onCancel.mockReset();
+    await user.click(screen.getByText('t'));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it('danger variant applies red styling to the confirm button', () => {
+    render(
+      <ConfirmModal
+        open
+        title="t"
+        message="m"
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Delete' });
+    expect(btn.className).toMatch(/bg-red/);
+  });
+
+  it('Tab cycles focus between cancel and confirm (focus trap)', async () => {
+    const user = userEvent.setup();
+    render(
+      <ConfirmModal
+        open
+        title="t"
+        message="m"
+        cancelLabel="No"
+        confirmLabel="Yes"
+        onConfirm={noop}
+        onCancel={noop}
+      />,
+    );
+    // Starts on confirm (Yes). Tab → cycles to cancel (No).
+    expect(screen.getByRole('button', { name: 'Yes' })).toHaveFocus();
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'No' })).toHaveFocus();
+    // Tab again from the last focusable — trap cycles back to first.
+    await user.tab();
+    expect(screen.getByRole('button', { name: 'Yes' })).toHaveFocus();
+  });
+});

--- a/src/components/__tests__/NoteEditor.test.tsx
+++ b/src/components/__tests__/NoteEditor.test.tsx
@@ -190,4 +190,47 @@ describe('NoteEditor — WAT-204 reconcile banner', () => {
     await user.click(screen.getByRole('button', { name: /preview/i }));
     expect(screen.getByText(/nothing to preview yet/i)).toBeInTheDocument();
   });
+
+  // --- WAT-405: delete-confirmation modal ---
+
+  it('Delete opens the confirm modal and only calls delete_note after Confirm', async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'delete_note') return undefined;
+      return undefined;
+    });
+    useAppStore.setState({ currentNote: note({ id: 'note:9' }) });
+    const user = userEvent.setup();
+    render(<NoteEditor />);
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    // Modal is open; backend has NOT been called yet.
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    const earlyCall = mockInvoke.mock.calls.find((c) => c[0] === 'delete_note');
+    expect(earlyCall, 'delete_note must not fire until Confirm is clicked').toBeUndefined();
+
+    // Confirm the delete from inside the modal.
+    const modalDelete = Array.from(dialog.querySelectorAll('button'))
+      .find((b) => /delete/i.test(b.textContent ?? ''));
+    expect(modalDelete).toBeDefined();
+    await user.click(modalDelete!);
+
+    expect(mockInvoke).toHaveBeenCalledWith('delete_note', { id: 'note:9' });
+  });
+
+  it('Delete modal cancels cleanly (no IPC, no state change)', async () => {
+    useAppStore.setState({ currentNote: note({ id: 'note:42' }) });
+    const user = userEvent.setup();
+    render(<NoteEditor />);
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    // Press Escape — modal closes, delete never fires.
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    const called = mockInvoke.mock.calls.find((c) => c[0] === 'delete_note');
+    expect(called).toBeUndefined();
+  });
 });

--- a/src/components/__tests__/SnippetsSettings.test.tsx
+++ b/src/components/__tests__/SnippetsSettings.test.tsx
@@ -110,7 +110,10 @@ describe('SnippetsSettings — WAT-301 CRUD', () => {
     expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
   });
 
-  it('delete invokes delete_snippet with the id', async () => {
+  it('delete opens a confirmation modal and only fires delete_snippet after Confirm', async () => {
+    // WAT-405: destructive actions go through ConfirmModal, not
+    // straight to the backend. Clicking Delete in the editor opens
+    // the modal; the IPC fires only when the user confirms.
     const existing = snippet({ id: 'snip:42' });
     mockInvoke.mockImplementation(async (cmd: string) => {
       if (cmd === 'list_snippets') return [existing];
@@ -123,6 +126,43 @@ describe('SnippetsSettings — WAT-301 CRUD', () => {
     await user.click(screen.getByText(';addr'));
     await user.click(screen.getByRole('button', { name: /delete/i }));
 
+    // Modal is up — IPC not yet fired.
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    const deleteBefore = mockInvoke.mock.calls.find((c) => c[0] === 'delete_snippet');
+    expect(deleteBefore, 'delete_snippet must not fire until Confirm').toBeUndefined();
+
+    // Click the confirm button inside the dialog (not the one in the editor).
+    const confirmBtn = screen.getAllByRole('button', { name: /delete/i })
+      .find((b) => dialog.contains(b));
+    expect(confirmBtn).toBeDefined();
+    await user.click(confirmBtn!);
+
     expect(mockInvoke).toHaveBeenCalledWith('delete_snippet', { id: 'snip:42' });
+  });
+
+  it('delete modal cancels cleanly without firing the IPC', async () => {
+    const existing = snippet({ id: 'snip:99' });
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === 'list_snippets') return [existing];
+      return undefined;
+    });
+    const user = userEvent.setup();
+    render(<SnippetsSettings />);
+
+    await screen.findByText(';addr');
+    await user.click(screen.getByText(';addr'));
+    await user.click(screen.getByRole('button', { name: /delete/i }));
+
+    // Cancel on the dialog.
+    const dialog = screen.getByRole('dialog');
+    const cancel = Array.from(dialog.querySelectorAll('button'))
+      .find((b) => /cancel/i.test(b.textContent ?? ''));
+    expect(cancel).toBeTruthy();
+    await user.click(cancel!);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    const called = mockInvoke.mock.calls.find((c) => c[0] === 'delete_snippet');
+    expect(called, 'cancel must not fire delete_snippet').toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
The three destructive actions in the UI — **Delete note**, **Clear clipboard history**, **Delete snippet** — used to fire silently on click. An accidental click would lose data with no confirmation. Now each routes through an in-app `ConfirmModal`; native `window.confirm` is avoided (it fights Tauri window transparency on Windows).

Closes #25.

## New component
`src/components/ConfirmModal.tsx` — themed dialog with:
- `role="dialog"` + `aria-modal` + `aria-labelledby` for screen readers
- Focus lands on confirm on open; Tab cycles only between cancel/confirm (focus trap)
- Enter confirms, Escape cancels, backdrop click cancels
- `variant="danger"` tints the confirm button red
- `fixed inset-0` — viewport-relative, doesn't depend on ancestor positioning

## Wired up
| Site | Before | After |
|---|---|---|
| NoteEditor Delete | silent delete | confirm modal |
| Settings → Clear Clipboard History | silent clear | confirm modal |
| SnippetsSettings Delete | silent delete | confirm modal with trigger + name |

## Test plan
- [x] `cargo test` — 334 passed (no backend changes)
- [x] `npm test` — 75 passed (+11: 8 ConfirmModal, 2 NoteEditor delete flow, replace 1 direct-delete snippet test with 2 modal-flow tests)
- [x] `npm run build` — clean
- [ ] Manual: Delete a note, Clear Clipboard History, Delete a snippet — modal appears each time; Enter/Escape/backdrop click all work.

## Note on ticket wording
The ticket said "Replace `window.confirm`/`alert`". The codebase didn't actually use either — the destructive actions just fired without any confirmation. The underlying UX problem was real; this PR addresses it with the intended modal pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)