### PR TITLE
WAT-406: Notifications drawer for non-fatal events

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod files;
 mod indexers;
 mod layout;
 mod notes;
+mod notifications;
 mod scratchpad;
 mod search;
 mod snippets;
@@ -18,6 +19,7 @@ use clipboard::ClipboardManager;
 use config::settings::Settings;
 use files::{FileEntry, FileSearchManager, indexer::FileIndexer};
 use notes::NotesManager;
+use notifications::NotificationsManager;
 use scratchpad::ScratchpadManager;
 use snippets::SnippetsManager;
 use warnings::{StartupWarning, StartupWarnings};
@@ -52,6 +54,10 @@ struct AppState {
     /// should be rendered in the UI — e.g., the global hotkey couldn't be
     /// registered because another app already owns it.
     startup_warnings: StartupWarnings,
+    /// WAT-406: in-memory drawer of non-fatal events. Startup warnings
+    /// also push here so the drawer keeps a visible history after the
+    /// banner is dismissed.
+    notifications: NotificationsManager,
 }
 
 #[tauri::command]
@@ -774,6 +780,28 @@ fn dismiss_startup_warning(id: String, state: State<AppState>) -> bool {
     state.startup_warnings.dismiss(&id)
 }
 
+// --- WAT-406: notifications drawer ---
+
+#[tauri::command]
+fn list_notifications(state: State<AppState>) -> Vec<notifications::Notification> {
+    state.notifications.list()
+}
+
+#[tauri::command]
+fn notifications_unread_count(state: State<AppState>) -> usize {
+    state.notifications.unread_count()
+}
+
+#[tauri::command]
+fn dismiss_notification(id: String, state: State<AppState>) -> bool {
+    state.notifications.dismiss(&id)
+}
+
+#[tauri::command]
+fn dismiss_all_notifications(state: State<AppState>) -> usize {
+    state.notifications.dismiss_all()
+}
+
 /// WAT-206: open the OS file browser at the config directory. Action
 /// target for the "Open config folder" button on the settings-schema
 /// warning banner.
@@ -824,16 +852,33 @@ pub fn run() {
     // as WAT-105's shortcut failures. Build the container up-front so we
     // can push before handing it off to `manage()`.
     let startup_warnings = StartupWarnings::new();
+    // WAT-406: mirror every startup warning into the notifications
+    // drawer so dismissing the loud banner doesn't erase the history.
+    let notifications = NotificationsManager::new();
     if let Some(config::SettingsWarning::FromNewerVersion {
         file_version,
         supported_version,
     }) = settings_warning
     {
         startup_warnings.record_settings_from_newer_version(file_version, supported_version);
+        notifications.push(
+            notifications::Severity::Warning,
+            "Settings from a newer Watson",
+            &format!(
+                "Your config.toml is schema v{file_version}; this binary supports up to v{supported_version}. Running with defaults."
+            ),
+        );
     }
     // WAT-303: surface ignore-pattern compile errors through the same
     // banner channel. Valid patterns already applied above.
     startup_warnings.record_invalid_clipboard_filters(&pattern_errors);
+    if !pattern_errors.is_empty() {
+        notifications.push(
+            notifications::Severity::Warning,
+            "Clipboard filter errors",
+            &format!("{} pattern(s) failed to compile: {}", pattern_errors.len(), pattern_errors.join("; ")),
+        );
+    }
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
@@ -851,6 +896,7 @@ pub fn run() {
             file_search,
             snippets: SnippetsManager::new(Arc::clone(&db)),
             startup_warnings,
+            notifications,
         })
         .setup(|app| {
             let window = app.get_webview_window("main").unwrap();
@@ -886,6 +932,15 @@ pub fn run() {
                 state
                     .startup_warnings
                     .record_shortcut_unavailable(hotkey_label, &e.to_string());
+                // WAT-406: mirror into the drawer so the history
+                // persists after the loud banner is dismissed.
+                state.notifications.push(
+                    notifications::Severity::Warning,
+                    "Hotkey unavailable",
+                    &format!(
+                        "Couldn't register {hotkey_label}: {e}. Another app may be using it."
+                    ),
+                );
             }
 
             // Create system tray (macOS and Windows only - Linux requires appindicator)
@@ -950,6 +1005,10 @@ pub fn run() {
             create_snippet,
             update_snippet,
             delete_snippet,
+            list_notifications,
+            notifications_unread_count,
+            dismiss_notification,
+            dismiss_all_notifications,
             get_startup_warnings,
             dismiss_startup_warning,
             open_config_folder,

--- a/src-tauri/src/notifications/mod.rs
+++ b/src-tauri/src/notifications/mod.rs
@@ -1,0 +1,295 @@
+//! WAT-406: in-memory notifications queue for non-fatal events.
+//!
+//! Where the [`StartupWarnings`](crate::warnings) surface is a loud
+//! banner for conditions the user must know about RIGHT NOW (hotkey
+//! broken, config from the future), the notifications drawer is the
+//! quieter scroll-of-history: index failures, update-check errors,
+//! any eprintln! that wants a user-visible record.
+//!
+//! Entries are in-memory only for this version — restart wipes them.
+//! That matches the intent (notifications are transient; persistent
+//! issues reappear via the loud banner on next startup) and keeps
+//! this module dependency-free. Persistence can be a follow-up if
+//! users ask for it.
+//!
+//! ## 24h auto-expiry
+//!
+//! [`list`] returns only notifications created within the last 24
+//! hours. `list` also garbage-collects expired rows in place so the
+//! Vec doesn't grow unboundedly across a long uptime.
+//!
+//! ## Relationship to StartupWarnings
+//!
+//! The two surfaces are complementary. When a startup warning is
+//! recorded, it is ALSO pushed to the notifications queue — the
+//! banner is dismissable and loud; the drawer entry is the
+//! persistent record the user can revisit.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+
+pub const EXPIRY_SECS: i64 = 24 * 60 * 60; // 24 hours
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Notification {
+    pub id: String,
+    pub severity: Severity,
+    pub title: String,
+    pub message: String,
+    /// Unix seconds when the entry was pushed.
+    pub created_at: i64,
+    /// Set to true when the user dismisses the entry. Dismissed entries
+    /// stop appearing in the unread count but remain in `list()` until
+    /// expiry so users who dismissed by accident can still see them
+    /// briefly.
+    #[serde(default)]
+    pub dismissed: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct NotificationsManager {
+    inner: Mutex<Vec<Notification>>,
+    /// Monotonic counter to break timestamp ties in the same millisecond.
+    /// Avoids the sub-ms id collision we hit on the notes / snippets
+    /// modules — under rapid pushes, ids still stay unique.
+    next_seq: Mutex<u64>,
+}
+
+impl NotificationsManager {
+    pub fn new() -> Self {
+        NotificationsManager::default()
+    }
+
+    /// Push a new notification. Returns its id so the caller can
+    /// deduplicate or dismiss it later if desired.
+    pub fn push(&self, severity: Severity, title: &str, message: &str) -> String {
+        self.push_at(severity, title, message, Utc::now().timestamp())
+    }
+
+    /// Variant with an explicit `now` timestamp. Used by tests to
+    /// control created_at without relying on sleeps.
+    pub fn push_at(
+        &self,
+        severity: Severity,
+        title: &str,
+        message: &str,
+        now: i64,
+    ) -> String {
+        let mut seq = self.next_seq.lock().unwrap();
+        *seq += 1;
+        let id = format!("notif:{now}-{s}", s = *seq);
+        drop(seq);
+        let n = Notification {
+            id: id.clone(),
+            severity,
+            title: title.to_string(),
+            message: message.to_string(),
+            created_at: now,
+            dismissed: false,
+        };
+        self.inner.lock().unwrap().push(n);
+        id
+    }
+
+    /// Return all active (non-expired) notifications, newest-first.
+    /// Garbage-collects expired entries in place.
+    pub fn list(&self) -> Vec<Notification> {
+        self.list_at(Utc::now().timestamp())
+    }
+
+    pub fn list_at(&self, now: i64) -> Vec<Notification> {
+        let mut inner = self.inner.lock().unwrap();
+        let threshold = now - EXPIRY_SECS;
+        inner.retain(|n| n.created_at >= threshold);
+        let mut out = inner.clone();
+        out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        out
+    }
+
+    /// Count of un-dismissed, un-expired notifications. Drives the
+    /// header badge.
+    pub fn unread_count(&self) -> usize {
+        self.unread_count_at(Utc::now().timestamp())
+    }
+
+    pub fn unread_count_at(&self, now: i64) -> usize {
+        let mut inner = self.inner.lock().unwrap();
+        let threshold = now - EXPIRY_SECS;
+        inner.retain(|n| n.created_at >= threshold);
+        inner.iter().filter(|n| !n.dismissed).count()
+    }
+
+    /// Mark one notification as dismissed. Returns true if a matching
+    /// entry was found. Idempotent: dismissing an already-dismissed or
+    /// unknown id returns false without erroring.
+    pub fn dismiss(&self, id: &str) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        for n in inner.iter_mut() {
+            if n.id == id && !n.dismissed {
+                n.dismissed = true;
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Dismiss every currently-active notification. Returns the
+    /// number that were actually flipped (not already dismissed).
+    pub fn dismiss_all(&self) -> usize {
+        let mut inner = self.inner.lock().unwrap();
+        let mut n = 0;
+        for entry in inner.iter_mut() {
+            if !entry.dismissed {
+                entry.dismissed = true;
+                n += 1;
+            }
+        }
+        n
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: i64 = 1_750_000_000;
+    const HOUR: i64 = 3600;
+
+    // --- push / list ordering ---
+
+    #[test]
+    fn new_is_empty() {
+        let m = NotificationsManager::new();
+        assert!(m.list().is_empty());
+        assert_eq!(m.unread_count(), 0);
+    }
+
+    #[test]
+    fn list_returns_newest_first() {
+        let m = NotificationsManager::new();
+        m.push_at(Severity::Info, "first", "", NOW - 10);
+        m.push_at(Severity::Info, "second", "", NOW - 5);
+        m.push_at(Severity::Info, "third", "", NOW);
+
+        let out = m.list_at(NOW);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].title, "third");
+        assert_eq!(out[1].title, "second");
+        assert_eq!(out[2].title, "first");
+    }
+
+    #[test]
+    fn push_generates_unique_ids_even_within_same_second() {
+        // Sub-second push bursts used to produce id collisions on
+        // other modules; the seq counter prevents that here.
+        let m = NotificationsManager::new();
+        let id1 = m.push_at(Severity::Info, "a", "", NOW);
+        let id2 = m.push_at(Severity::Info, "b", "", NOW);
+        assert_ne!(id1, id2);
+    }
+
+    // --- 24h expiry ---
+
+    #[test]
+    fn list_drops_entries_older_than_24h() {
+        let m = NotificationsManager::new();
+        m.push_at(Severity::Info, "stale", "", NOW - 25 * HOUR);
+        m.push_at(Severity::Info, "fresh", "", NOW - HOUR);
+        let out = m.list_at(NOW);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].title, "fresh");
+    }
+
+    #[test]
+    fn list_keeps_entries_exactly_at_24h_boundary() {
+        // Boundary pin: an entry at now-24h is still inside the window.
+        let m = NotificationsManager::new();
+        m.push_at(Severity::Info, "edge", "", NOW - 24 * HOUR);
+        assert_eq!(m.list_at(NOW).len(), 1);
+    }
+
+    #[test]
+    fn expired_entries_are_gc_d_in_place_not_leaked() {
+        // Defensive: after listing, the backing Vec shouldn't still
+        // hold the stale entries (would grow unboundedly across a
+        // long uptime).
+        let m = NotificationsManager::new();
+        m.push_at(Severity::Info, "stale", "", NOW - 25 * HOUR);
+        let _ = m.list_at(NOW);
+        // Peek via `unread_count_at` which ALSO gc's. A second list
+        // should show the Vec is small — indirect but sufficient.
+        assert_eq!(m.unread_count_at(NOW), 0);
+    }
+
+    // --- dismissal ---
+
+    #[test]
+    fn dismiss_marks_entry_and_excludes_from_unread_count() {
+        let m = NotificationsManager::new();
+        let id = m.push_at(Severity::Warning, "alert", "", NOW);
+        assert_eq!(m.unread_count_at(NOW), 1);
+        assert!(m.dismiss(&id));
+        assert_eq!(m.unread_count_at(NOW), 0);
+    }
+
+    #[test]
+    fn dismiss_does_not_remove_from_list_only_flags() {
+        // The user can still see a dismissed entry in the drawer —
+        // it's out of the unread count, but the row persists until
+        // expiry so recent dismissals are discoverable.
+        let m = NotificationsManager::new();
+        let id = m.push_at(Severity::Info, "t", "", NOW);
+        m.dismiss(&id);
+        let out = m.list_at(NOW);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].dismissed);
+    }
+
+    #[test]
+    fn dismiss_returns_false_for_unknown_id() {
+        let m = NotificationsManager::new();
+        assert!(!m.dismiss("notif:nope"));
+    }
+
+    #[test]
+    fn dismiss_is_idempotent_for_already_dismissed() {
+        // A race where two tabs/buttons both fire dismiss for the
+        // same id: the second call returns false (nothing to do)
+        // without error.
+        let m = NotificationsManager::new();
+        let id = m.push_at(Severity::Info, "t", "", NOW);
+        assert!(m.dismiss(&id));
+        assert!(!m.dismiss(&id));
+    }
+
+    #[test]
+    fn dismiss_all_flips_every_active_entry() {
+        let m = NotificationsManager::new();
+        m.push_at(Severity::Info, "a", "", NOW);
+        m.push_at(Severity::Warning, "b", "", NOW);
+        m.push_at(Severity::Error, "c", "", NOW);
+        assert_eq!(m.dismiss_all(), 3);
+        assert_eq!(m.unread_count_at(NOW), 0);
+    }
+
+    #[test]
+    fn dismiss_all_reports_count_of_actually_flipped() {
+        // One entry was already dismissed individually — only two
+        // are "new dismissals" for the bulk call.
+        let m = NotificationsManager::new();
+        m.push_at(Severity::Info, "a", "", NOW);
+        let b = m.push_at(Severity::Info, "b", "", NOW);
+        m.push_at(Severity::Info, "c", "", NOW);
+        m.dismiss(&b);
+        assert_eq!(m.dismiss_all(), 2);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { NoteEditor } from './components/NoteEditor';
 import { StartupWarningBanner } from './components/StartupWarningBanner';
 import { SnippetsSettings } from './components/SnippetsSettings';
 import { ConfirmModal } from './components/ConfirmModal';
+import { NotificationsDrawer } from './components/NotificationsDrawer';
 import { useAppStore } from './stores/app';
 import type { WebSearch } from './types';
 
@@ -39,6 +40,48 @@ function SettingsIcon({ onClick }: { onClick: () => void }) {
         <circle cx="12" cy="12" r="3" />
         <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
       </svg>
+    </button>
+  );
+}
+
+/**
+ * WAT-406: header bell icon that opens the notifications drawer. A
+ * small red dot appears on the bell when unread count > 0.
+ */
+function NotificationsBell({
+  count,
+  onClick,
+}: {
+  count: number;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={count > 0 ? `Notifications (${count} unread)` : 'Notifications'}
+      title="Notifications"
+      className="relative p-1.5 rounded-lg hover:bg-[var(--selected)] transition-colors"
+    >
+      <svg
+        className="w-5 h-5 text-gray-400 hover:text-gray-600"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      </svg>
+      {count > 0 && (
+        <span
+          data-testid="notifications-badge"
+          aria-hidden="true"
+          className="absolute top-0.5 right-0.5 min-w-[16px] h-4 px-1 text-[10px] font-semibold text-white bg-red-500 rounded-full flex items-center justify-center"
+        >
+          {count > 9 ? '9+' : count}
+        </span>
+      )}
     </button>
   );
 }
@@ -493,12 +536,30 @@ function SettingsPanel({ onClose }: { onClose: () => void }) {
 }
 
 function App() {
-  const { loadSettings, reindexApps, settings, showSettings, setShowSettings, resizeWindow, scratchpadVisible, noteEditorVisible, loadReservedPrefixes, setQuery } = useAppStore();
+  const {
+    loadSettings,
+    reindexApps,
+    settings,
+    showSettings,
+    setShowSettings,
+    resizeWindow,
+    scratchpadVisible,
+    noteEditorVisible,
+    loadReservedPrefixes,
+    setQuery,
+    loadNotifications,
+    notificationsUnread,
+    notificationsOpen,
+    setNotificationsOpen,
+  } = useAppStore();
 
   useEffect(() => {
     loadSettings();
     reindexApps();
     loadReservedPrefixes();
+    // WAT-406: load notifications + unread count on mount so the
+    // header badge reflects reality before the user clicks the bell.
+    loadNotifications();
     // WAT-304: populate the empty-query recents carousel on first paint
     // so the user doesn't have to type anything to see their recent apps
     // and files. Fires the same code path as clearing an existing query.
@@ -549,14 +610,22 @@ function App() {
           <WatsonLogo />
           <span className="text-lg font-semibold">Watson</span>
         </div>
-        <SettingsIcon onClick={() => setShowSettings(!showSettings)} />
+        <div className="flex items-center gap-1">
+          <NotificationsBell
+            count={notificationsUnread}
+            onClick={() => setNotificationsOpen(!notificationsOpen)}
+          />
+          <SettingsIcon onClick={() => setShowSettings(!showSettings)} />
+        </div>
       </div>
 
       <StartupWarningBanner onOpenSettings={() => setShowSettings(true)} />
 
       <SearchBar />
 
-      {noteEditorVisible ? (
+      {notificationsOpen ? (
+        <NotificationsDrawer />
+      ) : noteEditorVisible ? (
         <NoteEditor />
       ) : scratchpadVisible ? (
         <Scratchpad />

--- a/src/components/NotificationsDrawer.tsx
+++ b/src/components/NotificationsDrawer.tsx
@@ -1,0 +1,122 @@
+import { useAppStore } from '../stores/app';
+import type { Notification, NotificationSeverity } from '../types';
+
+/**
+ * WAT-406: drawer panel listing non-fatal notifications.
+ *
+ * Rendered below the search bar when `notificationsOpen` is true (the
+ * store toggle the header bell icon drives). Complementary to the
+ * WAT-105 startup-warning banner — startup warnings push HERE too so
+ * dismissing the loud banner doesn't erase the record.
+ */
+export function NotificationsDrawer() {
+  const { notifications, notificationsOpen, dismissNotification, dismissAllNotifications, setNotificationsOpen } =
+    useAppStore();
+
+  if (!notificationsOpen) return null;
+
+  const active = notifications.filter((n) => !n.dismissed);
+  const dismissed = notifications.filter((n) => n.dismissed);
+
+  return (
+    <div
+      role="region"
+      aria-label="Notifications"
+      className="border-t border-[var(--border)] max-h-[320px] overflow-y-auto p-3"
+    >
+      <div className="flex justify-between items-center mb-2">
+        <h3 className="text-sm font-semibold">Notifications</h3>
+        <div className="flex gap-2 items-center">
+          {active.length > 0 && (
+            <button
+              type="button"
+              onClick={() => void dismissAllNotifications()}
+              className="text-xs text-gray-500 hover:text-gray-700"
+            >
+              Dismiss all
+            </button>
+          )}
+          <button
+            type="button"
+            aria-label="Close notifications"
+            onClick={() => setNotificationsOpen(false)}
+            className="text-gray-400 hover:text-gray-600"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {notifications.length === 0 && (
+        <p className="text-xs text-gray-400 italic">No notifications.</p>
+      )}
+
+      {active.map((n) => (
+        <NotificationRow key={n.id} notification={n} onDismiss={() => void dismissNotification(n.id)} />
+      ))}
+
+      {dismissed.length > 0 && (
+        <>
+          <p className="text-[10px] uppercase tracking-wider text-gray-400 mt-3 mb-1">Dismissed</p>
+          {dismissed.map((n) => (
+            <NotificationRow key={n.id} notification={n} onDismiss={null} />
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function NotificationRow({
+  notification,
+  onDismiss,
+}: {
+  notification: Notification;
+  onDismiss: (() => void) | null;
+}) {
+  const tone = severityTone(notification.severity);
+  return (
+    <div
+      className={`flex items-start gap-2 p-2 mb-1 rounded-lg ${tone.bg} ${
+        notification.dismissed ? 'opacity-60' : ''
+      }`}
+    >
+      <span className={`mt-0.5 text-xs font-medium ${tone.fg}`} aria-hidden="true">
+        {tone.icon}
+      </span>
+      <div className="flex-1 min-w-0">
+        <p className={`text-xs font-medium truncate ${tone.fg}`}>{notification.title}</p>
+        <p className="text-xs text-gray-600 dark:text-gray-300 mt-0.5">{notification.message}</p>
+        <p className="text-[10px] text-gray-400 mt-1">
+          {new Date(notification.created_at * 1000).toLocaleString()}
+        </p>
+      </div>
+      {onDismiss && (
+        <button
+          type="button"
+          aria-label={`Dismiss: ${notification.title}`}
+          onClick={onDismiss}
+          className="shrink-0 text-gray-400 hover:text-gray-600"
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function severityTone(s: NotificationSeverity): { bg: string; fg: string; icon: string } {
+  switch (s) {
+    case 'error':
+      return { bg: 'bg-red-50 dark:bg-red-900/20', fg: 'text-red-700 dark:text-red-300', icon: '!' };
+    case 'warning':
+      return { bg: 'bg-amber-50 dark:bg-amber-900/20', fg: 'text-amber-700 dark:text-amber-300', icon: '⚠' };
+    case 'info':
+    default:
+      return { bg: 'bg-blue-50 dark:bg-blue-900/20', fg: 'text-blue-700 dark:text-blue-300', icon: 'i' };
+  }
+}

--- a/src/components/__tests__/NotificationsDrawer.test.tsx
+++ b/src/components/__tests__/NotificationsDrawer.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { invoke } from '@tauri-apps/api/core';
+import { NotificationsDrawer } from '../NotificationsDrawer';
+import { useAppStore } from '../../stores/app';
+import type { Notification } from '../../types';
+
+const mockInvoke = vi.mocked(invoke);
+
+function resetStore() {
+  useAppStore.setState({
+    query: '',
+    results: [],
+    selectedIndex: 0,
+    settings: null,
+    isLoading: false,
+    showSettings: false,
+    scratchpad: '',
+    scratchpadVisible: false,
+    currentNote: null,
+    noteEditorVisible: false,
+    startupWarnings: [],
+    reservedPrefixes: [],
+    notifications: [],
+    notificationsUnread: 0,
+    notificationsOpen: true, // test drawer in its open state
+  });
+}
+
+function notif(overrides: Partial<Notification> = {}): Notification {
+  return {
+    id: overrides.id ?? 'notif:1',
+    severity: overrides.severity ?? 'warning',
+    title: overrides.title ?? 'Hotkey unavailable',
+    message: overrides.message ?? "Couldn't register Alt+Space: already in use.",
+    created_at: overrides.created_at ?? 1_750_000_000,
+    dismissed: overrides.dismissed,
+  };
+}
+
+describe('NotificationsDrawer — WAT-406', () => {
+  beforeEach(() => {
+    resetStore();
+    mockInvoke.mockReset();
+    mockInvoke.mockImplementation(async () => undefined);
+  });
+
+  it('renders nothing when notificationsOpen is false', () => {
+    useAppStore.setState({ notificationsOpen: false });
+    const { container } = render(<NotificationsDrawer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows an empty-state message when there are no notifications', () => {
+    render(<NotificationsDrawer />);
+    expect(screen.getByText(/no notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders active notifications with title + message', () => {
+    useAppStore.setState({
+      notifications: [
+        notif({ id: 'a', title: 'Hotkey unavailable', message: 'Alt+Space taken' }),
+        notif({ id: 'b', title: 'Filter error', message: 'invalid regex' }),
+      ],
+      notificationsUnread: 2,
+    });
+    render(<NotificationsDrawer />);
+
+    expect(screen.getByText('Hotkey unavailable')).toBeInTheDocument();
+    expect(screen.getByText('Alt+Space taken')).toBeInTheDocument();
+    expect(screen.getByText('Filter error')).toBeInTheDocument();
+  });
+
+  it('clicking the per-row X dismisses the notification via IPC', async () => {
+    useAppStore.setState({
+      notifications: [notif({ id: 'notif:42' })],
+      notificationsUnread: 1,
+    });
+    const user = userEvent.setup();
+    render(<NotificationsDrawer />);
+
+    await user.click(screen.getByRole('button', { name: /dismiss: hotkey unavailable/i }));
+
+    expect(mockInvoke).toHaveBeenCalledWith('dismiss_notification', { id: 'notif:42' });
+    // Optimistic update: row moved to dismissed group; unread count now 0.
+    expect(useAppStore.getState().notificationsUnread).toBe(0);
+  });
+
+  it('"Dismiss all" invokes dismiss_all_notifications and flips all to dismissed', async () => {
+    useAppStore.setState({
+      notifications: [
+        notif({ id: 'a' }),
+        notif({ id: 'b' }),
+      ],
+      notificationsUnread: 2,
+    });
+    const user = userEvent.setup();
+    render(<NotificationsDrawer />);
+
+    await user.click(screen.getByRole('button', { name: /dismiss all/i }));
+
+    expect(mockInvoke).toHaveBeenCalledWith('dismiss_all_notifications');
+    expect(useAppStore.getState().notificationsUnread).toBe(0);
+  });
+
+  it('separates active from dismissed with a heading, and dismissed rows have no X', () => {
+    useAppStore.setState({
+      notifications: [
+        notif({ id: 'a', title: 'Active one' }),
+        notif({ id: 'b', title: 'Gone one', dismissed: true }),
+      ],
+      notificationsUnread: 1,
+    });
+    render(<NotificationsDrawer />);
+
+    expect(screen.getByText('Active one')).toBeInTheDocument();
+    expect(screen.getByText('Gone one')).toBeInTheDocument();
+    // Only the active row has a dismiss button; dismissed ones don't.
+    expect(screen.getAllByRole('button', { name: /dismiss:/i })).toHaveLength(1);
+    // Heading appears above dismissed entries.
+    expect(screen.getByText(/dismissed/i)).toBeInTheDocument();
+  });
+
+  it('close button sets notificationsOpen=false', async () => {
+    useAppStore.setState({ notifications: [notif()] });
+    const user = userEvent.setup();
+    render(<NotificationsDrawer />);
+
+    await user.click(screen.getByRole('button', { name: /close notifications/i }));
+
+    expect(useAppStore.getState().notificationsOpen).toBe(false);
+  });
+});

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,6 +1,13 @@
 import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
-import type { SearchResult, Settings, Scratchpad, Note, StartupWarning } from '../types';
+import type {
+  SearchResult,
+  Settings,
+  Scratchpad,
+  Note,
+  StartupWarning,
+  Notification,
+} from '../types';
 
 interface AppState {
   query: string;
@@ -15,6 +22,9 @@ interface AppState {
   noteEditorVisible: boolean;
   startupWarnings: StartupWarning[];
   reservedPrefixes: string[];
+  notifications: Notification[];
+  notificationsUnread: number;
+  notificationsOpen: boolean;
 
   setQuery: (query: string) => void;
   setSelectedIndex: (index: number) => void;
@@ -43,6 +53,10 @@ interface AppState {
   loadReservedPrefixes: () => Promise<void>;
   pinClipboardEntry: (id: string) => Promise<void>;
   unpinClipboardEntry: (id: string) => Promise<void>;
+  loadNotifications: () => Promise<void>;
+  setNotificationsOpen: (open: boolean) => void;
+  dismissNotification: (id: string) => Promise<void>;
+  dismissAllNotifications: () => Promise<void>;
 }
 
 // Height constants
@@ -68,6 +82,9 @@ export const useAppStore = create<AppState>((set, get) => ({
   noteEditorVisible: false,
   startupWarnings: [],
   reservedPrefixes: [],
+  notifications: [],
+  notificationsUnread: 0,
+  notificationsOpen: false,
 
   setQuery: async (query: string) => {
     set({ query, selectedIndex: 0 });
@@ -357,6 +374,55 @@ export const useAppStore = create<AppState>((set, get) => ({
       await get().setQuery(get().query);
     } catch (e) {
       console.error('Failed to unpin clipboard entry:', e);
+    }
+  },
+
+  // WAT-406: notifications drawer. Keep the unread count in the store
+  // so the header badge updates without an extra IPC on every render.
+  loadNotifications: async () => {
+    try {
+      const [list, unread] = await Promise.all([
+        invoke<Notification[]>('list_notifications'),
+        invoke<number>('notifications_unread_count'),
+      ]);
+      set({ notifications: list, notificationsUnread: unread });
+    } catch (e) {
+      console.error('Failed to load notifications:', e);
+    }
+  },
+
+  setNotificationsOpen: (open: boolean) => {
+    set({ notificationsOpen: open });
+    if (open) {
+      // Re-fetch when the drawer opens so late-arriving notifications
+      // (e.g. an update check that just failed) appear without a
+      // separate refresh affordance.
+      void get().loadNotifications();
+    }
+  },
+
+  dismissNotification: async (id: string) => {
+    // Optimistic: mark dismissed locally, decrement unread.
+    const current = get().notifications;
+    const next = current.map((n) =>
+      n.id === id ? { ...n, dismissed: true } : n,
+    );
+    const unread = next.filter((n) => !n.dismissed).length;
+    set({ notifications: next, notificationsUnread: unread });
+    try {
+      await invoke('dismiss_notification', { id });
+    } catch (e) {
+      console.error('Failed to dismiss notification:', e);
+    }
+  },
+
+  dismissAllNotifications: async () => {
+    const next = get().notifications.map((n) => ({ ...n, dismissed: true }));
+    set({ notifications: next, notificationsUnread: 0 });
+    try {
+      await invoke('dismiss_all_notifications');
+    } catch (e) {
+      console.error('Failed to dismiss all notifications:', e);
     }
   },
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,19 @@ export type StartupWarningKind =
   | 'settings_from_newer_version'
   | 'invalid_clipboard_filter';
 
+// WAT-406: notifications drawer
+
+export type NotificationSeverity = 'info' | 'warning' | 'error';
+
+export interface Notification {
+  id: string;
+  severity: NotificationSeverity;
+  title: string;
+  message: string;
+  created_at: number;
+  dismissed?: boolean;
+}
+
 export interface StartupWarning {
   id: string;
   kind: StartupWarningKind;


### PR DESCRIPTION
## Summary
Startup warnings (WAT-105, WAT-206, WAT-303's clipboard-filter errors) used to surface only as loud banners — dismiss once, gone forever. And other eprintln! sites went to stderr only. This PR adds a notifications drawer in the header: bell icon with unread-count badge, slide-down panel listing every non-fatal event from the last 24h.

Startup warnings now mirror into the drawer so dismissing the banner preserves the history.

Closes #26.

## Surfaces at a glance
| Event | Banner (WAT-105) | Drawer (WAT-406) |
|---|---|---|
| Hotkey unavailable | ✅ | ✅ (mirror) |
| Settings from newer Watson | ✅ | ✅ (mirror) |
| Clipboard filter errors | ✅ | ✅ (mirror) |
| Future: index failures, update errors | — | ✅ (via `push`) |

The drawer is the general-purpose log; the banner is reserved for the loud "you must see this now" moment at startup.

## Implementation
- `NotificationsManager` in Rust: in-memory, 24h auto-expiry, monotonic seq counter in ids (avoids the sub-ms collision we hit on notes/snippets).
- Four Tauri commands: list / unread_count / dismiss / dismiss_all.
- Header `NotificationsBell` with unread badge (capped at "9+").
- `NotificationsDrawer` with active entries at top (per-row X), dismissed in a collapsed group below (visible until expiry for easy recovery).
- Optimistic dismissal in the store so rows update immediately.
- App mount fetches once so the bell badge is accurate before the user clicks.

## Test plan
- [x] `cargo test` — 346 passed (+12 in `notifications`)
- [x] `npm test` — 82 passed (+7 drawer tests)
- [x] `npm run build` — clean
- [ ] Manual: hold another app on Alt+Space → launch Watson → banner appears AND bell shows 1. Dismiss the banner. Click the bell → drawer shows the same warning. Dismiss it from the drawer → unread goes to 0; entry moves to "Dismissed" group.

## Notes
- Persistence deferred. Notifications are intentionally transient; persistent issues reappear via the loud banner on next startup.
- The drawer UI is the foundation: future tickets migrate scattered eprintln! sites to push through `state.notifications` rather than console-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)