### PR TITLE
feat: UIA browser tab switching + bare-letter shortcut fix

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4809,6 +4809,7 @@ dependencies = [
  "toml 0.8.2",
  "urlencoding",
  "walkdir",
+ "windows",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,5 +35,15 @@ meval = "0.2"
 regex = "1"
 tokio = { version = "1", features = ["full"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+# UI Automation for browser tab enumeration. Only needed on Windows;
+# the target.cfg gate keeps macOS / Linux builds slim.
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Variant",
+    "Win32_UI_Accessibility",
+] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/actions/browser_tabs.rs
+++ b/src-tauri/src/actions/browser_tabs.rs
@@ -1,0 +1,301 @@
+//! Browser-tab enumeration via Windows UI Automation (UIA).
+//!
+//! Why this module exists:
+//!
+//! Browser tabs are NOT operating-system windows. Brave, Chrome, Edge,
+//! and Firefox each render every tab inside a single Win32 HWND using
+//! their own internal compositor. `EnumWindows` cannot see tabs — it
+//! sees only the parent browser window. The parent's `GetWindowTextW`
+//! returns the active tab's title, so a window switcher built on
+//! Win32 enumeration alone collapses every browser-window's tabs into
+//! a single switcher entry.
+//!
+//! UIA is Microsoft's accessibility framework. Browsers populate a
+//! cross-process accessibility tree describing their UI semantically:
+//! each tab strip exposes a sequence of `TabItem` controls with the
+//! tab's title as its `Name` property. Screen readers use the same
+//! tree. We use it to enumerate tabs and to invoke selection on a
+//! specific tab.
+//!
+//! ## Approach
+//!
+//! 1. Initialize COM once per thread (apartment-threaded).
+//! 2. Get the singleton `IUIAutomation` interface via CoCreateInstance.
+//! 3. For a browser window's HWND, get its `IUIAutomationElement` root.
+//! 4. Build a `PropertyCondition(ControlType == TabItem)` and
+//!    `FindAll` descendants matching it.
+//! 5. Read each tab's `Name` for display.
+//! 6. To switch: re-find the same tab (by index, since it's stable
+//!    within a query), invoke `SelectionItemPattern.Select()` on it,
+//!    then `SetForegroundWindow` on the parent so the browser comes
+//!    to front with the chosen tab active.
+//!
+//! ## Performance
+//!
+//! UIA tree walks cross process boundaries and are slow (~50-200ms
+//! per browser window). Cache enumerated tabs per HWND with a 1-second
+//! TTL so repeated keystrokes during a single search don't cost a
+//! tree walk per row update.
+//!
+//! ## Coverage
+//!
+//! Brave / Chrome / Edge share the Chromium AX tree shape — they
+//! work identically. Firefox surfaces tabs with the same
+//! `ControlType.TabItem` but the tree shape differs slightly; the
+//! generic `FindAll` query handles it. Other Chromium variants
+//! (Vivaldi, Arc, Opera) inherit from Chromium and should work
+//! without per-browser code.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TabEntry {
+    /// Owning browser window HWND, serialized as i64 for JSON safety
+    /// (matches the convention in `actions::windows::WindowEntry`).
+    pub window_hwnd: i64,
+    /// Process exe basename of the owning window — used in the
+    /// description ("Switch to Brave: …").
+    pub process_name: String,
+    /// Tab name as displayed in the browser tab strip.
+    pub name: String,
+    /// Stable index within the tab strip at enumeration time. Used by
+    /// `focus_browser_tab` to find the same tab again at activation.
+    /// If the user reorders tabs between enum and activation, the
+    /// wrong tab might be focused — acceptable for v1; UIA Runtime
+    /// IDs would be the proper fix.
+    pub index: i32,
+}
+
+/// Process names that get tab enumeration. Anything else is skipped —
+/// most apps don't have tabs and the UIA query would return empty
+/// anyway, but the early skip avoids ~50ms/window on the search hot
+/// path. Lower-cased for comparison.
+const BROWSER_PROCESS_NAMES: &[&str] = &[
+    "brave",
+    "chrome",
+    "msedge",
+    "firefox",
+    "vivaldi",
+    "opera",
+    "arc",
+];
+
+pub fn is_browser_process(process_name: &str) -> bool {
+    let lower = process_name.to_ascii_lowercase();
+    BROWSER_PROCESS_NAMES.iter().any(|b| lower.contains(b))
+}
+
+#[cfg(target_os = "windows")]
+pub use win::{focus_browser_tab, get_browser_tabs};
+
+#[cfg(not(target_os = "windows"))]
+pub fn get_browser_tabs(_hwnd: i64, _process_name: &str) -> Result<Vec<TabEntry>, String> {
+    // UIA is Windows-only. macOS would need NSAccessibility / AXUIElement;
+    // Linux has AT-SPI but browser support is patchy. Both are follow-up
+    // work — return empty so the search path stays well-behaved.
+    Ok(vec![])
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn focus_browser_tab(_hwnd: i64, _index: i32) -> Result<(), String> {
+    Err("Browser tab switching is Windows-only in v1".to_string())
+}
+
+// --- Windows UIA implementation ---
+
+#[cfg(target_os = "windows")]
+mod win {
+    use super::TabEntry;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::ffi::c_void;
+    use std::time::{Duration, Instant};
+
+    use windows::core::{Interface, BSTR};
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::System::Com::{
+        CoCreateInstance, CoInitializeEx, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED,
+    };
+    use windows::Win32::System::Variant::VARIANT;
+    use windows::Win32::UI::Accessibility::{
+        CUIAutomation, IUIAutomation, IUIAutomationElement, IUIAutomationSelectionItemPattern,
+        TreeScope_Descendants, UIA_ControlTypePropertyId, UIA_NamePropertyId,
+        UIA_SelectionItemPatternId, UIA_TabItemControlTypeId,
+    };
+
+    /// Per-thread cache: HWND → (last_enum_at, tabs).
+    /// 1-second TTL keeps the search snappy when the user is typing
+    /// without forcing a UIA tree walk on every keystroke.
+    thread_local! {
+        static TAB_CACHE: RefCell<HashMap<i64, (Instant, Vec<TabEntry>)>>
+            = RefCell::new(HashMap::new());
+        static UIA: RefCell<Option<IUIAutomation>> = const { RefCell::new(None) };
+    }
+
+    const CACHE_TTL: Duration = Duration::from_secs(1);
+
+    /// Lazily initialize COM (apartment-threaded; idempotent — calling
+    /// twice on the same thread returns S_FALSE which we ignore) and
+    /// the UIA singleton. Stores the IUIAutomation in TLS so repeated
+    /// queries don't re-create the COM object.
+    fn uia_get() -> Result<IUIAutomation, String> {
+        UIA.with(|cell| {
+            if let Some(existing) = cell.borrow().as_ref() {
+                return Ok(existing.clone());
+            }
+            unsafe {
+                // CoInitializeEx returns S_OK on first init,
+                // RPC_E_CHANGED_MODE if a different threading model is
+                // already set, S_FALSE if already in this mode. We
+                // tolerate S_FALSE (already-init) and surface
+                // RPC_E_CHANGED_MODE as an error.
+                let hr = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+                if hr.is_err() {
+                    let code = hr.0 as u32;
+                    // S_FALSE == 0x00000001: already initialized in this mode. OK.
+                    if code != 0x00000001 {
+                        return Err(format!(
+                            "CoInitializeEx failed: 0x{code:08X}"
+                        ));
+                    }
+                }
+
+                let automation: IUIAutomation =
+                    CoCreateInstance(&CUIAutomation, None, CLSCTX_INPROC_SERVER)
+                        .map_err(|e| format!("CoCreateInstance(UIA): {e}"))?;
+                *cell.borrow_mut() = Some(automation.clone());
+                Ok(automation)
+            }
+        })
+    }
+
+    /// Enumerate tabs in the browser window identified by `hwnd`.
+    /// Cached for 1 second. Returns [] when the window has no
+    /// TabItem controls — empty tabbed browsers, or a non-browser
+    /// window we accidentally queried.
+    pub fn get_browser_tabs(hwnd: i64, process_name: &str) -> Result<Vec<TabEntry>, String> {
+        // Cache lookup: short-circuit if we have a fresh result.
+        let cached = TAB_CACHE.with(|cell| {
+            cell.borrow()
+                .get(&hwnd)
+                .filter(|(at, _)| at.elapsed() < CACHE_TTL)
+                .map(|(_, v)| v.clone())
+        });
+        if let Some(tabs) = cached {
+            return Ok(tabs);
+        }
+
+        let tabs = enumerate_uncached(hwnd, process_name)?;
+
+        TAB_CACHE.with(|cell| {
+            cell.borrow_mut().insert(hwnd, (Instant::now(), tabs.clone()));
+        });
+        Ok(tabs)
+    }
+
+    fn enumerate_uncached(hwnd: i64, process_name: &str) -> Result<Vec<TabEntry>, String> {
+        let automation = uia_get()?;
+        unsafe {
+            let root: IUIAutomationElement = automation
+                .ElementFromHandle(HWND(hwnd as *mut c_void))
+                .map_err(|e| format!("ElementFromHandle: {e}"))?;
+
+            // Build: ControlType == TabItem.
+            let condition = automation
+                .CreatePropertyCondition(
+                    UIA_ControlTypePropertyId,
+                    &VARIANT::from(UIA_TabItemControlTypeId.0),
+                )
+                .map_err(|e| format!("CreatePropertyCondition: {e}"))?;
+
+            let elements = root
+                .FindAll(TreeScope_Descendants, &condition)
+                .map_err(|e| format!("FindAll: {e}"))?;
+
+            let count = elements.Length().unwrap_or(0);
+            let mut out = Vec::with_capacity(count as usize);
+            for i in 0..count {
+                let element = match elements.GetElement(i) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                let name: BSTR = element.CurrentName().unwrap_or_default();
+                let name_string = name.to_string();
+                if name_string.trim().is_empty() {
+                    continue;
+                }
+                out.push(TabEntry {
+                    window_hwnd: hwnd,
+                    process_name: process_name.to_string(),
+                    name: name_string,
+                    index: i,
+                });
+            }
+            Ok(out)
+        }
+    }
+
+    /// Switch to the tab at `index` in the browser window `hwnd`.
+    /// Re-enumerates so a stale cache doesn't operate on a moved tab,
+    /// then invokes `SelectionItemPattern.Select()` and brings the
+    /// parent window to front so the user actually sees the activation.
+    pub fn focus_browser_tab(hwnd: i64, index: i32) -> Result<(), String> {
+        let automation = uia_get()?;
+        unsafe {
+            let root: IUIAutomationElement = automation
+                .ElementFromHandle(HWND(hwnd as *mut c_void))
+                .map_err(|e| format!("ElementFromHandle: {e}"))?;
+
+            let condition = automation
+                .CreatePropertyCondition(
+                    UIA_ControlTypePropertyId,
+                    &VARIANT::from(UIA_TabItemControlTypeId.0),
+                )
+                .map_err(|e| format!("CreatePropertyCondition: {e}"))?;
+
+            let elements = root
+                .FindAll(TreeScope_Descendants, &condition)
+                .map_err(|e| format!("FindAll: {e}"))?;
+
+            let count = elements.Length().unwrap_or(0);
+            if index < 0 || index >= count {
+                return Err(format!(
+                    "tab index {index} out of range (browser has {count} tabs)"
+                ));
+            }
+
+            let tab = elements
+                .GetElement(index)
+                .map_err(|e| format!("GetElement({index}): {e}"))?;
+
+            // Get the SelectionItemPattern. UIA returns the pattern
+            // as IUnknown; we cast to the typed pattern interface.
+            let pattern_unknown = tab
+                .GetCurrentPattern(UIA_SelectionItemPatternId)
+                .map_err(|e| format!("GetCurrentPattern(SelectionItem): {e}"))?;
+            let selection: IUIAutomationSelectionItemPattern = pattern_unknown
+                .cast()
+                .map_err(|e| format!("cast SelectionItemPattern: {e}"))?;
+
+            selection.Select().map_err(|e| format!("Select: {e}"))?;
+
+            // SelectionItem.Select() activates the tab in-process but
+            // doesn't touch z-order / foreground. Bring the parent
+            // window to front so the user sees the new active tab.
+            // Reuses the same direct-Win32 approach from
+            // actions::windows::focus_window — keeps the
+            // foreground-rights handling consistent.
+            crate::actions::windows::focus_window(hwnd)?;
+        }
+        Ok(())
+    }
+
+    /// Required so VARIANT::from(UIA_TabItemControlTypeId.0) compiles —
+    /// `UIA_TabItemControlTypeId.0` is an i32 (the underlying control
+    /// type id). VARIANT::from(i32) exists. Sanity-asserted here.
+    #[allow(dead_code)]
+    fn _assert_variant_from_i32() {
+        let _ = VARIANT::from(UIA_TabItemControlTypeId.0);
+        let _ = UIA_NamePropertyId; // silence dead_code if unused
+    }
+}

--- a/src-tauri/src/actions/mod.rs
+++ b/src-tauri/src/actions/mod.rs
@@ -1,3 +1,4 @@
+pub mod browser_tabs;
 pub mod system;
 pub mod window;
 pub mod windows;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -446,6 +446,40 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
     // Gemini Improvement #6: Add open windows to search results.
     if let Ok(windows) = actions::windows::get_open_windows() {
         for window in windows {
+            // For browser windows, also surface every tab as its own
+            // switcher row via UIA. The window-level row stays in the
+            // list — selecting it focuses the window without changing
+            // the active tab. Selecting a tab row activates that tab.
+            let is_browser = actions::browser_tabs::is_browser_process(&window.process_name);
+            if is_browser {
+                if let Ok(tabs) =
+                    actions::browser_tabs::get_browser_tabs(window.hwnd, &window.process_name)
+                {
+                    for tab in tabs {
+                        items.push(SearchResult {
+                            // Composite id: window HWND + tab index. Stable
+                            // for React keying within a single enum.
+                            id: format!("tab:{:x}:{}", tab.window_hwnd, tab.index),
+                            name: tab.name.clone(),
+                            description: format!("Tab in {}", tab.process_name),
+                            icon: Some("browser_tab".to_string()),
+                            result_type: ResultType::BrowserTab,
+                            // Rank tabs slightly above plain windows so
+                            // when both match, the more specific tab
+                            // surfaces first.
+                            score: 200,
+                            frecency_score: 0.0,
+                            preview: None,
+                            pinned: false,
+                            action: SearchAction::FocusBrowserTab {
+                                hwnd: tab.window_hwnd,
+                                index: tab.index,
+                            },
+                        });
+                    }
+                }
+            }
+
             items.push(SearchResult {
                 // HWND is unique per window; using it as the id means
                 // multi-window apps (Brave with three browser windows,
@@ -537,6 +571,9 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
             paste_snippet_via_os()
         }
         SearchAction::FocusWindow { hwnd } => actions::windows::focus_window(hwnd),
+        SearchAction::FocusBrowserTab { hwnd, index } => {
+            actions::browser_tabs::focus_browser_tab(hwnd, index)
+        }
     }
 }
 

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -59,6 +59,11 @@ pub enum ResultType {
     Snippet,
     /// Gemini Improvement #6: an open window that can be switched to.
     OpenWindow,
+    /// A specific browser tab inside an open browser window. Surfaced
+    /// via UIA enumeration of the tab strip; selecting one invokes
+    /// `SelectionItemPattern.Select()` on the underlying TabItem and
+    /// brings the parent window to front.
+    BrowserTab,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -77,6 +82,10 @@ pub enum SearchAction {
     /// serialized as i64 — fits in JSON's safe-integer range because
     /// user-mode HWNDs stay under 2^53 on Windows.)
     FocusWindow { hwnd: i64 },
+    /// Switch to a specific browser tab inside an open browser window.
+    /// `hwnd` is the parent window; `index` is the tab's position in
+    /// the strip at enumeration time.
+    FocusBrowserTab { hwnd: i64, index: i32 },
 }
 
 pub struct SearchEngine {

--- a/src/components/ResultItem.tsx
+++ b/src/components/ResultItem.tsx
@@ -162,6 +162,19 @@ function WindowIcon() {
   );
 }
 
+function BrowserTabIcon() {
+  return (
+    <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-sky-400 to-indigo-600 flex items-center justify-center">
+      <svg className="w-5 h-5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M3 12h18" />
+        <path d="M12 3a9 9 0 0 1 0 18" />
+        <path d="M12 3a9 9 0 0 0 0 18" />
+      </svg>
+    </div>
+  );
+}
+
 function DefaultIcon() {
   return (
     <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-gray-400 to-gray-600 flex items-center justify-center">
@@ -194,6 +207,8 @@ export function ResultItem({ result, isSelected, onClick, index }: ResultItemPro
         return <SnippetIcon />;
       case 'open_window':
         return <WindowIcon />;
+      case 'browser_tab':
+        return <BrowserTabIcon />;
       default:
         return <DefaultIcon />;
     }
@@ -219,6 +234,8 @@ export function ResultItem({ result, isSelected, onClick, index }: ResultItemPro
         return 'Snip';
       case 'open_window':
         return 'Win';
+      case 'browser_tab':
+        return 'Tab';
       default:
         return '';
     }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -11,7 +11,6 @@ export function SearchBar() {
     executeSelected,
     hideWindow,
     setShowScratchpad,
-    openNewNote,
     actionMenuOpen,
     toggleActionMenu,
     closeActionMenu,
@@ -59,32 +58,31 @@ export function SearchBar() {
       return;
     }
 
-    // Chained shortcuts when search is empty
-    if (query === '') {
-      // Scratchpad trigger: 's' or '`'
-      if (e.key === 's' || e.key === '`') {
-        e.preventDefault();
-        setShowScratchpad(true);
-        return;
-      }
-      // New note trigger: 'n' (shift+n for search mode)
-      if (e.key === 'n' && !e.shiftKey) {
-        e.preventDefault();
-        openNewNote();
-        return;
-      }
-      // Notes search: 'N' (shift+n)
-      if (e.key === 'N' || (e.key === 'n' && e.shiftKey)) {
-        e.preventDefault();
-        setQuery('n ');
-        return;
-      }
-      // Files search: 'f'
-      if (e.key === 'f') {
-        e.preventDefault();
-        setQuery('f ');
-        return;
-      }
+    // Empty-query shortcuts. Single-letter shortcuts used to be:
+    //   s        → scratchpad
+    //   n        → new note editor
+    //   N / n+⇧  → write 'n ' (notes search prefix)
+    //   f        → write 'f ' (files search prefix)
+    // The problem: those single keystrokes ate ANY search starting
+    // with that letter. Tab named "Slack" → press s → scratchpad.
+    // Search for "Notion" → press n → new note editor. Etc.
+    //
+    // The fix: bare letters now flow into the query like normal.
+    // Shortcuts require a discriminator:
+    //   `        → scratchpad (backtick alone, since it's rare in
+    //              real searches it can stay as a single-key shortcut)
+    //   's '     → scratchpad (typed two chars; intercepted in store
+    //              setQuery so the 's ' is never sent to the backend)
+    //   'n '     → notes search (already a backend route — works)
+    //   'f '     → files search (already a backend route — works)
+    //
+    // The bare-`n` (open new note editor) shortcut goes away here;
+    // typing `n ` shows recent notes, and a "Create new note" entry
+    // can be added there as a follow-up.
+    if (query === '' && e.key === '`') {
+      e.preventDefault();
+      setShowScratchpad(true);
+      return;
     }
 
     switch (e.key) {

--- a/src/components/__tests__/SearchBar.test.tsx
+++ b/src/components/__tests__/SearchBar.test.tsx
@@ -164,18 +164,20 @@ describe('SearchBar keyboard contract', () => {
     expect(hideCall, 'hide_window should be called when query was empty').toBeDefined();
   });
 
-  // --- empty-query chained shortcuts ---
-
-  it("typing 's' on an empty query opens the scratchpad", async () => {
-    const user = userEvent.setup();
-    render(<SearchBar />);
-
-    await user.keyboard('s');
-
-    expect(useAppStore.getState().scratchpadVisible).toBe(true);
-    // The 's' character must NOT have been inserted into the query.
-    expect(useAppStore.getState().query).toBe('');
-  });
+  // --- empty-query shortcuts (post-letter+space rework) ---
+  //
+  // Bare-letter shortcuts used to fire on a single keystroke from
+  // empty: `s` → scratchpad, `n` → new note, `N` → notes search,
+  // `f` → files search. They were removed because they ate any
+  // search starting with that letter (a tab named "Slack" was
+  // unreachable; typing "Notion" opened the new-note editor).
+  //
+  // Now: bare letters flow into the query like normal. Discriminated
+  // shortcuts:
+  //   `        → scratchpad (single-key OK; rare in real searches)
+  //   's '     → scratchpad (typed two chars; intercepted in store)
+  //   'n '     → notes search (existing backend route, unchanged)
+  //   'f '     → files search (existing backend route, unchanged)
 
   it('typing backtick on an empty query opens the scratchpad', async () => {
     const user = userEvent.setup();
@@ -187,34 +189,50 @@ describe('SearchBar keyboard contract', () => {
     expect(useAppStore.getState().query).toBe('');
   });
 
-  it("typing 'n' on an empty query opens a new note", async () => {
+  it("typing 's' alone leaves it as part of the search query", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+
+    await user.keyboard('s');
+
+    // 's' is now a normal search character; scratchpad does NOT open.
+    expect(useAppStore.getState().scratchpadVisible).toBe(false);
+    expect(useAppStore.getState().query).toBe('s');
+  });
+
+  it("'s ' (s + space) opens the scratchpad and clears the query", async () => {
+    const user = userEvent.setup();
+    render(<SearchBar />);
+
+    await user.keyboard('s ');
+
+    // After the space, the store's setQuery interceptor fires the
+    // shortcut and clears the input — same end state as the old
+    // single-key trigger, just discriminated.
+    expect(useAppStore.getState().scratchpadVisible).toBe(true);
+    expect(useAppStore.getState().query).toBe('');
+  });
+
+  it("typing 'n' alone leaves it as part of the search query (no editor)", async () => {
     const user = userEvent.setup();
     render(<SearchBar />);
 
     await user.keyboard('n');
 
-    expect(useAppStore.getState().noteEditorVisible).toBe(true);
-    expect(useAppStore.getState().currentNote).toBeNull();
-    expect(useAppStore.getState().query).toBe('');
-  });
-
-  it("Shift+n on an empty query enters notes-search mode ('n ')", async () => {
-    const user = userEvent.setup();
-    render(<SearchBar />);
-
-    await user.keyboard('{Shift>}n{/Shift}');
-
-    expect(useAppStore.getState().query).toBe('n ');
+    // 'n' no longer opens the new note editor — flows into the query.
     expect(useAppStore.getState().noteEditorVisible).toBe(false);
+    expect(useAppStore.getState().query).toBe('n');
   });
 
-  it("typing 'f' on an empty query enters files-search mode ('f ')", async () => {
+  it("typing 'f' alone leaves it as part of the search query", async () => {
     const user = userEvent.setup();
     render(<SearchBar />);
 
     await user.keyboard('f');
 
-    expect(useAppStore.getState().query).toBe('f ');
+    // 'f' no longer auto-writes 'f '; user types the space themselves
+    // when they want files-search mode.
+    expect(useAppStore.getState().query).toBe('f');
   });
 
   // --- shortcut suppression once the query has content ---

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -93,6 +93,19 @@ export const useAppStore = create<AppState>((set, get) => ({
   actionMenuOpen: false,
 
   setQuery: async (query: string) => {
+    // Frontend-only shortcut: 's ' (s + trailing space) opens the
+    // scratchpad. Single-letter `s` no longer intercepts because it
+    // collided with searches starting with that letter (a tab named
+    // "Slack" was unreachable). The `s ` form is also rare enough in
+    // real text that the shortcut still feels deliberate. Bare
+    // backtick remains a one-key trigger; handled in SearchBar so it
+    // never enters the query at all.
+    if (query === 's ') {
+      set({ query: '', selectedIndex: 0, results: [], actionMenuOpen: false });
+      get().setShowScratchpad(true);
+      return;
+    }
+
     // WAT-404: changing the query invalidates whatever menu was open
     // for the prior selection.
     set({ query, selectedIndex: 0, actionMenuOpen: false });

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface SearchResult {
   name: string;
   description: string;
   icon: string | null;
-  result_type: 'application' | 'web_search' | 'system_command' | 'clipboard' | 'note' | 'file' | 'calculation' | 'snippet' | 'open_window';
+  result_type: 'application' | 'web_search' | 'system_command' | 'clipboard' | 'note' | 'file' | 'calculation' | 'snippet' | 'open_window' | 'browser_tab';
   /** The primary fuzzy-match score from the backend engine. */
   score: number;
   /** Gemini Improvement #2: secondary frecency score (frequency + recency). */
@@ -23,7 +23,8 @@ export type SearchAction =
   | { type: 'open_note'; note_id: string }
   | { type: 'open_file'; path: string }
   | { type: 'paste_snippet'; expansion: string }
-  | { type: 'focus_window'; hwnd: number };
+  | { type: 'focus_window'; hwnd: number }
+  | { type: 'focus_browser_tab'; hwnd: number; index: number };
 
 export interface Snippet {
   id: string;


### PR DESCRIPTION
## The eye poke

Watson's "Switch to..." picker only saw OS-level windows. Browser tabs aren't OS windows — Brave / Chrome / Edge / Firefox each render every tab inside a single Win32 HWND using their own internal compositor. The window-level title returned by `GetWindowTextW` is the active tab's title, so a switcher built on Win32 enumeration alone collapses every browser-window's tabs into one row.

This PR makes every tab a switchable row via Microsoft UI Automation — the same accessibility tree screen readers walk.

## How it works

1. COM init (apartment-threaded, idempotent).
2. Thread-local `IUIAutomation` singleton — created once, reused.
3. For each browser HWND surfaced by the existing `EnumWindows` pipeline:
   - Get the `IUIAutomationElement` root.
   - Build `PropertyCondition(ControlType == TabItem)`.
   - `FindAll(TreeScope_Descendants, ...)` to enumerate every tab.
   - Read each tab's `Name` for display, remember the index.
4. Selecting a tab row: re-find by index (browser may have re-laid out), `GetCurrentPattern(SelectionItem)`, `Select()`, then `focus_window` on the parent so the user sees the activation.

## Caching

UIA tree walks cross process boundaries and run ~50-200ms per browser window. A 1-second per-HWND TLS cache keeps keystrokes snappy — typing "g i t" triggers one walk per window per second, not three.

## Browser coverage

Brave / Chrome / Edge / Vivaldi / Opera / Arc share the Chromium AX tree shape and work identically. Firefox uses `TabItem` too with a slightly different tree shape — same generic query handles it. Non-browser windows are skipped before the COM call (matches against a process-name allowlist) so non-browser apps don't pay the UIA cost.

## Bonus fix: bare-letter shortcuts no longer eat searches

Surfaced during UIA testing: a tab named "Slack" was unreachable because pressing `s` from an empty query opened the scratchpad. Same fault on `n` (new note editor), `N` (notes-search prefix), `f` (files-search prefix).

Now bare letters flow into the query like normal text. Shortcuts require a discriminator:
- `` ` `` → scratchpad (single-key still OK; rare in real searches)
- `s ` → scratchpad (s + trailing space; intercepted in store)
- `n ` → notes search (existing backend route)
- `f ` → files search (existing backend route)

The bare-`n` (open new note editor) shortcut goes away. `n ` shows recent notes; a "Create new note" entry there is a follow-up.

## Test plan

- [x] `cargo test` — 347 passed
- [x] `npm test` — 103 passed (4 SearchBar tests rewritten for the new shortcut semantics)
- [x] `npm run build` — clean
- [x] Manual: opened Brave with N tabs, searched for a tab title, hit Enter — Brave came to front with that exact tab activated.
- [x] Manual: pressing `s` no longer opens the scratchpad mid-search.
- [ ] Manual on macOS / Linux: should compile and run; tab enumeration returns empty (UIA is Windows-only). Window-level focus still works via the cross-platform `focus_window` path.

## Limitations

- Per-tab UIA Runtime IDs would be more robust than positional index — if the user reorders tabs between picker open and Enter, the wrong tab activates. Acceptable for v1.
- macOS / Linux tab enumeration: `get_browser_tabs` returns empty. AT-SPI on Linux works for some browsers; NSAccessibility on macOS works for Safari + Chrome via AXUIElement. Both are separate tickets.

## Dependency

Adds `windows = "0.61"` (target.cfg gated to Windows) with the `Win32_System_Com`, `Win32_System_Variant`, and `Win32_UI_Accessibility` features. Same major version Tauri already pulls in transitively, so no tree bloat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)