### PR TITLE
feat(linux): X11 switcher backend (closes #62, partial — Wayland deferred)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "watson"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "arboard",
  "chrono",
@@ -4810,6 +4810,7 @@ dependencies = [
  "urlencoding",
  "walkdir",
  "windows",
+ "x11rb",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,5 +45,13 @@ windows = { version = "0.61", features = [
     "Win32_UI_Accessibility",
 ] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# X11 client for window enumeration + focus on X11 sessions. Default
+# features include the pure-Rust `rust_connection` so we don't pick up
+# a libxcb build-time dependency. Wayland support (wlr-foreign-
+# toplevel) is a follow-up issue; in the meantime the runtime falls
+# back to an explanatory error on Wayland sessions.
+x11rb = "0.13"
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/actions/windows.rs
+++ b/src-tauri/src/actions/windows.rs
@@ -306,12 +306,437 @@ pub fn focus_window(_hwnd: i64) -> Result<(), String> {
     Err("Window focusing not yet implemented on macOS".to_string())
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(target_os = "linux")]
+pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
+    linux::get_open_windows()
+}
+
+#[cfg(target_os = "linux")]
+pub fn focus_window(hwnd: i64) -> Result<(), String> {
+    linux::focus_window(hwnd)
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
     Ok(vec![])
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn focus_window(_hwnd: i64) -> Result<(), String> {
     Err("Window focusing not yet implemented on this platform".to_string())
+}
+
+// --- Linux backend ---
+//
+// Two display servers, two stories.
+//
+// X11 (P0): EWMH gives us everything we need. `_NET_CLIENT_LIST` on
+// the root window is the canonical "list of top-level windows
+// managed by the WM" — same role `EnumWindows` plays on Win32.
+// Activation is `_NET_ACTIVE_WINDOW` ClientMessage with source=2
+// ("pager / window switcher"), which compositors trust to bypass
+// focus-stealing prevention. Pure-Rust x11rb keeps libxcb out of
+// the build dep tree.
+//
+// Wayland (P1, follow-up issue): there is no portable cross-app
+// enumeration protocol — by design. wlr-foreign-toplevel works on
+// wlroots-based compositors (Sway, Hyprland, river); GNOME/Mutter
+// and KDE/KWin have no usable equivalent. Until the wlr port
+// lands, Wayland sessions return empty enumeration + an
+// explanatory error from focus_window. Detection is by
+// `XDG_SESSION_TYPE`.
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::WindowEntry;
+
+    enum Backend {
+        X11,
+        Wayland(String),
+    }
+
+    fn detect_backend() -> Backend {
+        let session_type = std::env::var("XDG_SESSION_TYPE")
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        if session_type == "wayland" {
+            let name = std::env::var("XDG_CURRENT_DESKTOP")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "Wayland".to_string());
+            Backend::Wayland(name)
+        } else {
+            // x11, tty, or missing — try X11. If there's no X server
+            // the connect call returns Err and the caller gets a
+            // clean error string instead of a silent empty result.
+            Backend::X11
+        }
+    }
+
+    pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
+        match detect_backend() {
+            Backend::X11 => x11::get_open_windows(),
+            Backend::Wayland(_) => Ok(Vec::new()),
+        }
+    }
+
+    pub fn focus_window(hwnd: i64) -> Result<(), String> {
+        match detect_backend() {
+            Backend::X11 => x11::focus_window(hwnd),
+            Backend::Wayland(name) => Err(format!(
+                "Window switching is not supported on {name} (Wayland session). \
+                 Log in with an X11 session to use the switcher; \
+                 Wayland support is tracked in a separate issue."
+            )),
+        }
+    }
+
+    /// Resolve a process name from a PID via `/proc/<pid>/comm`,
+    /// falling back to the `/proc/<pid>/exe` symlink basename, then
+    /// to "unknown". Sandboxed browsers (Snap, Flatpak) may block
+    /// reads from outside their namespace; treat errors as "unknown".
+    fn process_name_for_pid(pid: u32) -> String {
+        if let Ok(comm) = std::fs::read_to_string(format!("/proc/{pid}/comm")) {
+            let trimmed = comm.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+        if let Ok(path) = std::fs::read_link(format!("/proc/{pid}/exe")) {
+            if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
+                if !name.is_empty() {
+                    return name.to_string();
+                }
+            }
+        }
+        "unknown".to_string()
+    }
+
+    mod x11 {
+        use super::process_name_for_pid;
+        use super::super::WindowEntry;
+        use x11rb::connection::Connection;
+        use x11rb::protocol::xproto::{
+            AtomEnum, ClientMessageEvent, ConnectionExt as _, EventMask, Window,
+        };
+
+        /// Pre-interned atoms. Atoms don't change after server
+        /// startup so we cache them per `enumerate` call (creating an
+        /// X11 connection is itself a syscall round-trip; one set of
+        /// atom interns adds negligible cost on top).
+        struct Atoms {
+            net_client_list: u32,
+            net_wm_name: u32,
+            net_wm_pid: u32,
+            net_wm_window_type: u32,
+            net_wm_state: u32,
+            net_active_window: u32,
+            utf8_string: u32,
+            // Window types we explicitly reject (the rest are kept).
+            type_desktop: u32,
+            type_dock: u32,
+            type_toolbar: u32,
+            type_menu: u32,
+            type_splash: u32,
+            type_notification: u32,
+            type_dropdown_menu: u32,
+            type_popup_menu: u32,
+            type_tooltip: u32,
+            type_combo: u32,
+            type_dnd: u32,
+            // States we reject.
+            state_hidden: u32,
+        }
+
+        impl Atoms {
+            fn intern<C: Connection>(conn: &C) -> Result<Self, String> {
+                let intern = |name: &[u8]| -> Result<u32, String> {
+                    conn.intern_atom(false, name)
+                        .map_err(|e| format!("intern_atom({}): {e}", String::from_utf8_lossy(name)))?
+                        .reply()
+                        .map(|r| r.atom)
+                        .map_err(|e| format!("intern_atom reply: {e}"))
+                };
+                Ok(Self {
+                    net_client_list: intern(b"_NET_CLIENT_LIST")?,
+                    net_wm_name: intern(b"_NET_WM_NAME")?,
+                    net_wm_pid: intern(b"_NET_WM_PID")?,
+                    net_wm_window_type: intern(b"_NET_WM_WINDOW_TYPE")?,
+                    net_wm_state: intern(b"_NET_WM_STATE")?,
+                    net_active_window: intern(b"_NET_ACTIVE_WINDOW")?,
+                    utf8_string: intern(b"UTF8_STRING")?,
+                    type_desktop: intern(b"_NET_WM_WINDOW_TYPE_DESKTOP")?,
+                    type_dock: intern(b"_NET_WM_WINDOW_TYPE_DOCK")?,
+                    type_toolbar: intern(b"_NET_WM_WINDOW_TYPE_TOOLBAR")?,
+                    type_menu: intern(b"_NET_WM_WINDOW_TYPE_MENU")?,
+                    type_splash: intern(b"_NET_WM_WINDOW_TYPE_SPLASH")?,
+                    type_notification: intern(b"_NET_WM_WINDOW_TYPE_NOTIFICATION")?,
+                    type_dropdown_menu: intern(b"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU")?,
+                    type_popup_menu: intern(b"_NET_WM_WINDOW_TYPE_POPUP_MENU")?,
+                    type_tooltip: intern(b"_NET_WM_WINDOW_TYPE_TOOLTIP")?,
+                    type_combo: intern(b"_NET_WM_WINDOW_TYPE_COMBO")?,
+                    type_dnd: intern(b"_NET_WM_WINDOW_TYPE_DND")?,
+                    state_hidden: intern(b"_NET_WM_STATE_HIDDEN")?,
+                })
+            }
+
+            fn is_excluded_type(&self, atom: u32) -> bool {
+                atom == self.type_desktop
+                    || atom == self.type_dock
+                    || atom == self.type_toolbar
+                    || atom == self.type_menu
+                    || atom == self.type_splash
+                    || atom == self.type_notification
+                    || atom == self.type_dropdown_menu
+                    || atom == self.type_popup_menu
+                    || atom == self.type_tooltip
+                    || atom == self.type_combo
+                    || atom == self.type_dnd
+            }
+        }
+
+        /// Read a property as an array of 32-bit values (CARDINAL,
+        /// WINDOW, ATOM all share this representation in the wire
+        /// protocol).
+        fn get_prop_u32<C: Connection>(
+            conn: &C,
+            window: Window,
+            property: u32,
+            type_: impl Into<u32>,
+        ) -> Option<Vec<u32>> {
+            let reply = conn
+                .get_property(false, window, property, type_, 0, u32::MAX / 4)
+                .ok()?
+                .reply()
+                .ok()?;
+            if reply.format != 32 {
+                return None;
+            }
+            // value is little-endian on all current X11 servers we
+            // care about (we connect locally; protocol byte-order is
+            // negotiated client-side, x11rb selects native).
+            Some(
+                reply
+                    .value
+                    .chunks_exact(4)
+                    .map(|c| u32::from_ne_bytes([c[0], c[1], c[2], c[3]]))
+                    .collect(),
+            )
+        }
+
+        /// Read a UTF-8 property; falls back to legacy COMPOUND_TEXT
+        /// / STRING (`WM_NAME`) when `_NET_WM_NAME` is missing. Returns
+        /// `None` if the window has no usable title.
+        fn get_window_title<C: Connection>(
+            conn: &C,
+            window: Window,
+            atoms: &Atoms,
+        ) -> Option<String> {
+            // _NET_WM_NAME (UTF8_STRING) — preferred.
+            let cookie = conn
+                .get_property(false, window, atoms.net_wm_name, atoms.utf8_string, 0, u32::MAX / 4)
+                .ok()?;
+            if let Ok(reply) = cookie.reply() {
+                if !reply.value.is_empty() {
+                    if let Ok(s) = String::from_utf8(reply.value) {
+                        let trimmed = s.trim();
+                        if !trimmed.is_empty() {
+                            return Some(trimmed.to_string());
+                        }
+                    }
+                }
+            }
+            // WM_NAME — legacy ICCCM property; type is STRING (Latin-1).
+            let cookie = conn
+                .get_property(false, window, AtomEnum::WM_NAME, AtomEnum::STRING, 0, u32::MAX / 4)
+                .ok()?;
+            if let Ok(reply) = cookie.reply() {
+                if !reply.value.is_empty() {
+                    let s: String = reply.value.into_iter().map(char::from).collect();
+                    let trimmed = s.trim();
+                    if !trimmed.is_empty() {
+                        return Some(trimmed.to_string());
+                    }
+                }
+            }
+            None
+        }
+
+        pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
+            let (conn, screen_num) = x11rb::connect(None)
+                .map_err(|e| format!("X11 connect failed: {e}"))?;
+            let root = conn.setup().roots[screen_num].root;
+            let atoms = Atoms::intern(&conn)?;
+
+            // _NET_CLIENT_LIST is type WINDOW (atom). x11rb's typed
+            // AtomEnum variant for WINDOW lives on AtomEnum::WINDOW.
+            let client_list = get_prop_u32(&conn, root, atoms.net_client_list, AtomEnum::WINDOW)
+                .ok_or_else(|| {
+                    "_NET_CLIENT_LIST missing on root — window manager doesn't \
+                     advertise EWMH support, switcher unavailable"
+                        .to_string()
+                })?;
+
+            let our_pid = std::process::id();
+            let mut entries = Vec::with_capacity(client_list.len());
+
+            for w in client_list {
+                // Window type filter. Missing _NET_WM_WINDOW_TYPE is
+                // treated as NORMAL per EWMH §Application Window
+                // Properties.
+                if let Some(types) = get_prop_u32(&conn, w, atoms.net_wm_window_type, AtomEnum::ATOM) {
+                    if types.iter().any(|&t| atoms.is_excluded_type(t)) {
+                        continue;
+                    }
+                }
+
+                // _NET_WM_STATE filter — drop minimized windows so the
+                // switcher doesn't list things the user explicitly
+                // hid. (We could surface them with a marker, but
+                // matches Win32 behavior for now.)
+                if let Some(states) = get_prop_u32(&conn, w, atoms.net_wm_state, AtomEnum::ATOM) {
+                    if states.contains(&atoms.state_hidden) {
+                        continue;
+                    }
+                }
+
+                let title = match get_window_title(&conn, w, &atoms) {
+                    Some(t) => t,
+                    None => continue, // Skip untitled windows (matches Win32).
+                };
+
+                let pid = get_prop_u32(&conn, w, atoms.net_wm_pid, AtomEnum::CARDINAL)
+                    .and_then(|v| v.first().copied())
+                    .unwrap_or(0);
+
+                if pid != 0 && pid == our_pid {
+                    continue; // Skip Watson's own window.
+                }
+
+                let process_name = if pid == 0 {
+                    "unknown".to_string()
+                } else {
+                    process_name_for_pid(pid)
+                };
+
+                entries.push(WindowEntry {
+                    hwnd: w as i64,
+                    pid,
+                    process_name,
+                    title,
+                });
+            }
+
+            Ok(entries)
+        }
+
+        pub fn focus_window(hwnd: i64) -> Result<(), String> {
+            // Window IDs in X11 are 32-bit. Reject anything that
+            // can't possibly be a valid handle before opening the
+            // connection.
+            if hwnd <= 0 || hwnd > u32::MAX as i64 {
+                return Err(format!("invalid X11 window id: {hwnd}"));
+            }
+            let target: Window = hwnd as u32;
+
+            let (conn, screen_num) = x11rb::connect(None)
+                .map_err(|e| format!("X11 connect failed: {e}"))?;
+            let root = conn.setup().roots[screen_num].root;
+            let atoms = Atoms::intern(&conn)?;
+
+            // Sanity-check the window still exists. get_geometry is
+            // the cheapest existence probe; a closed window returns a
+            // BadWindow error which x11rb surfaces as Err.
+            conn.get_geometry(target)
+                .map_err(|e| format!("get_geometry({hwnd:#x}): {e}"))?
+                .reply()
+                .map_err(|_| format!("window {hwnd:#x} no longer exists"))?;
+
+            // EWMH §_NET_ACTIVE_WINDOW: data.l[0]=2 indicates source
+            // is a pager / window switcher; data.l[1] is the
+            // timestamp (0 = CurrentTime is acceptable for source=2);
+            // data.l[2] is the requestor's currently-active window
+            // (0 if none).
+            let event = ClientMessageEvent::new(32, target, atoms.net_active_window, [2u32, 0, 0, 0, 0]);
+            conn.send_event(
+                false,
+                root,
+                EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+                event,
+            )
+            .map_err(|e| format!("send_event: {e}"))?;
+            // Belt-and-suspenders: also raise. Most EWMH-compliant
+            // WMs will raise as part of activate, but minimal WMs
+            // (twm-likes, tiling WMs in floating mode) sometimes
+            // don't. configure_window with above-sibling=None lifts
+            // to the top of its sibling stack.
+            use x11rb::protocol::xproto::{ConfigureWindowAux, StackMode};
+            let _ = conn
+                .configure_window(target, &ConfigureWindowAux::new().stack_mode(StackMode::ABOVE));
+
+            conn.flush().map_err(|e| format!("flush: {e}"))?;
+            Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn detect_backend_wayland_session_with_desktop() {
+            // Save + restore so test ordering with detect_backend_x11
+            // doesn't leak. std::env::set_var is unsafe in newer Rust
+            // editions; we accept the test-only race risk.
+            let prior_st = std::env::var("XDG_SESSION_TYPE").ok();
+            let prior_de = std::env::var("XDG_CURRENT_DESKTOP").ok();
+            std::env::set_var("XDG_SESSION_TYPE", "wayland");
+            std::env::set_var("XDG_CURRENT_DESKTOP", "GNOME");
+            match detect_backend() {
+                Backend::Wayland(name) => assert_eq!(name, "GNOME"),
+                _ => panic!("expected Wayland(GNOME)"),
+            }
+            match prior_st {
+                Some(v) => std::env::set_var("XDG_SESSION_TYPE", v),
+                None => std::env::remove_var("XDG_SESSION_TYPE"),
+            }
+            match prior_de {
+                Some(v) => std::env::set_var("XDG_CURRENT_DESKTOP", v),
+                None => std::env::remove_var("XDG_CURRENT_DESKTOP"),
+            }
+        }
+
+        #[test]
+        fn detect_backend_x11_when_session_type_x11() {
+            let prior = std::env::var("XDG_SESSION_TYPE").ok();
+            std::env::set_var("XDG_SESSION_TYPE", "x11");
+            assert!(matches!(detect_backend(), Backend::X11));
+            match prior {
+                Some(v) => std::env::set_var("XDG_SESSION_TYPE", v),
+                None => std::env::remove_var("XDG_SESSION_TYPE"),
+            }
+        }
+
+        #[test]
+        fn process_name_for_self_pid_is_nonempty() {
+            // Reading /proc/<our_pid>/comm should always work for the
+            // running test process. The exact name isn't load-bearing
+            // (cargo test, watson, target/debug/...), only that we
+            // return something other than the "unknown" fallback —
+            // which would indicate a regression in the /proc reader.
+            let name = process_name_for_pid(std::process::id());
+            assert!(!name.is_empty());
+            assert_ne!(name, "unknown");
+        }
+
+        #[test]
+        fn process_name_for_invalid_pid_is_unknown() {
+            // PID 0 is the swapper/scheduler and never exposes
+            // /proc/0; PID 4_000_000_000 is well above any plausible
+            // running PID on 32-bit pid_max systems and almost
+            // certainly above 64-bit too. Both should fall through to
+            // "unknown".
+            assert_eq!(process_name_for_pid(0), "unknown");
+            assert_eq!(process_name_for_pid(4_000_000_000), "unknown");
+        }
+    }
 }


### PR DESCRIPTION
Closes #62 for the X11 path. Wayland is explicitly deferred to a follow-up issue per the scoping doc.

## Summary

Replaces the Linux stub in `actions/windows.rs` with a working X11 backend built on `x11rb`. Wayland sessions are detected via `XDG_SESSION_TYPE` and return an explanatory error from `focus_window` plus empty enumeration — never silent failure.

## What's in
- `get_open_windows()`: `_NET_CLIENT_LIST` enumeration + EWMH filter pipeline (window-type exclusions, hidden-state drop, untitled drop, self-PID drop)
- `focus_window()`: `_NET_ACTIVE_WINDOW` ClientMessage with source=2 (pager — bypasses focus-stealing prevention) + belt-and-suspenders `configure_window(stack_mode=ABOVE)`
- Title resolution with `_NET_WM_NAME` UTF-8 → `WM_NAME` Latin-1 fallback for older clients
- PID-to-process-name via `/proc/<pid>/comm` → `/proc/<pid>/exe` symlink → `"unknown"`
- Backend detection by `XDG_SESSION_TYPE`
- Tests for compositor detection + `/proc` reader (X11-server-free portions)

## What's out (separate follow-up issues)
- **Wayland**: wlr-foreign-toplevel-management for wlroots-based compositors (Sway, Hyprland, river); GNOME/Mutter and KDE/KWin require shell extensions or brittle D-Bus and stay deferred
- **Browser tabs on Linux**: existing `actions/browser_tabs.rs` non-Windows branch already returns `Ok(vec![])`, satisfying the AC's "explicitly deferred and the picker shows window-only entries on Linux without UI breakage" branch

## Test plan
- [x] `cargo check` on Windows — Linux code is `cfg`-gated, doesn't affect Windows build
- [ ] CI compile on Ubuntu 22.04 — depends on this run
- [ ] **Manual on a Linux X11 session (you'll need to test)**:
  - Open Watson, search a substring of an open window's title — confirm a "Win" row appears with the window's title and process name
  - Hit Enter — confirm the target window is raised and focused, including across multi-monitor setups
  - Try with a minimized window — should NOT appear (filtered by `_NET_WM_STATE_HIDDEN`)
  - Try with multiple windows of the same app (Brave with two windows) — confirm one row per window, not one per process
  - Confirm Watson's own window is excluded
- [ ] **Manual on a Wayland session**: search shows no "Win" rows; if you somehow get one (shouldn't happen but), pressing Enter shows the explanatory error toast
- [ ] **Manual: window closed between picker open and Enter** — confirm clean error rather than panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)