### PR TITLE
feat(macos): AX-based switcher backend (closes #61 partial — tabs deferred)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,11 +77,11 @@ dependencies = [
  "clipboard-win",
  "image",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
@@ -161,11 +161,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -656,7 +665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -1268,8 +1277,8 @@ checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
 dependencies = [
  "crossbeam-channel",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "once_cell",
  "serde",
  "thiserror 2.0.17",
@@ -2058,10 +2067,10 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "serde",
@@ -2155,6 +2164,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,23 +2191,39 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-cloud-kit",
- "objc2-core-data",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-text",
  "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -2192,8 +2233,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2203,8 +2256,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2215,7 +2268,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.10.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -2226,9 +2279,21 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.10.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2237,8 +2302,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2248,7 +2313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -2260,7 +2325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -2283,14 +2348,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -2301,7 +2378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -2311,8 +2388,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
 dependencies = [
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2322,9 +2411,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -2334,9 +2436,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2346,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
 ]
 
@@ -2357,9 +2459,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.10.0",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2369,11 +2471,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
 ]
@@ -2418,8 +2520,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
  "objc2-osa-kit",
  "serde",
  "serde_json",
@@ -3600,11 +3702,11 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2",
+ "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
  "raw-window-handle",
  "redox_syscall 0.5.18",
  "tracing",
@@ -3755,7 +3857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.6.2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
@@ -3772,9 +3874,9 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle",
@@ -3838,9 +3940,9 @@ dependencies = [
  "log",
  "mime",
  "muda",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "percent-encoding",
@@ -4036,7 +4138,7 @@ dependencies = [
  "gtk",
  "http",
  "jni",
- "objc2",
+ "objc2 0.6.3",
  "objc2-ui-kit",
  "objc2-web-kit",
  "raw-window-handle",
@@ -4060,9 +4162,9 @@ dependencies = [
  "http",
  "jni",
  "log",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -4490,11 +4592,11 @@ dependencies = [
  "dirs 6.0.0",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "serde",
@@ -4788,10 +4890,14 @@ version = "1.5.1"
 dependencies = [
  "arboard",
  "chrono",
+ "core-foundation",
  "directories",
  "dirs 5.0.1",
  "fuzzy-matcher",
  "meval",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "open",
  "regex",
  "rusqlite",
@@ -4965,10 +5071,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -5475,7 +5581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -5490,10 +5596,10 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,5 +53,16 @@ windows = { version = "0.61", features = [
 # back to an explanatory error on Wayland sessions.
 x11rb = "0.13"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Accessibility (AXUIElement) FFI declared inline; this gets us the
+# CF/Objective-C type plumbing we need to call the framework cleanly.
+# - core-foundation: CFString/CFArray/CFNumber/CFBoolean wrappers + retain/release
+# - objc2 + objc2-foundation + objc2-app-kit: NSWorkspace.runningApplications
+#   and NSRunningApplication.activate for cross-Space focus.
+core-foundation = "0.10"
+objc2 = "0.5"
+objc2-foundation = "0.2"
+objc2-app-kit = { version = "0.2", features = ["NSRunningApplication", "NSWorkspace"] }
+
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/actions/windows.rs
+++ b/src-tauri/src/actions/windows.rs
@@ -295,15 +295,12 @@ pub fn focus_window(hwnd: i64) -> Result<(), String> {
 
 #[cfg(target_os = "macos")]
 pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
-    // macOS support is a follow-up. Returning empty keeps the picker
-    // pipeline well-behaved (no panics, no error toast); the
-    // "Switch to…" feature simply doesn't surface results yet.
-    Ok(vec![])
+    macos::get_open_windows()
 }
 
 #[cfg(target_os = "macos")]
-pub fn focus_window(_hwnd: i64) -> Result<(), String> {
-    Err("Window focusing not yet implemented on macOS".to_string())
+pub fn focus_window(hwnd: i64) -> Result<(), String> {
+    macos::focus_window(hwnd)
 }
 
 #[cfg(target_os = "linux")]
@@ -325,6 +322,7 @@ pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
 pub fn focus_window(_hwnd: i64) -> Result<(), String> {
     Err("Window focusing not yet implemented on this platform".to_string())
 }
+
 
 // --- Linux backend ---
 //
@@ -737,6 +735,402 @@ mod linux {
             // "unknown".
             assert_eq!(process_name_for_pid(0), "unknown");
             assert_eq!(process_name_for_pid(4_000_000_000), "unknown");
+        }
+    }
+}
+
+// --- macOS backend ---
+//
+// macOS exposes per-app window lists through the Accessibility (AX)
+// API rather than a global enumeration like Win32 EnumWindows. We
+// iterate `NSWorkspace.runningApplications` for PIDs, then call
+// `AXUIElementCreateApplication(pid)` per app and read the
+// `kAXWindowsAttribute` array. AX gives us both enumeration AND
+// activation through one permission gate (Accessibility), which is
+// the cleanest UX — vs. CGWindowList which can't activate and since
+// macOS 14.4 redacts titles without Screen Recording permission too.
+//
+// Window handles are synthetic i64s. AX elements are CFTypeRefs
+// (opaque pointers, not stable identifiers like X11 window IDs or
+// Win32 HWNDs), so we maintain a side-table mapping our minted i64s
+// to retained AXUIElementRefs across the IPC boundary. Each
+// `get_open_windows` call rebuilds the table; old entries' refs are
+// released via the AXRef Drop.
+//
+// Out of scope here (separate follow-up issues):
+// - Browser tab enumeration via AX tree walk (separate issue).
+// - Full permission UX with deep-link to System Settings → Privacy
+//   & Security → Accessibility (this PR returns a clean error
+//   message; a polished StartupWarning is a follow-up).
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::WindowEntry;
+    use std::collections::HashMap;
+    use std::os::raw::{c_int, c_void};
+    use std::sync::{Mutex, OnceLock};
+
+    use core_foundation::array::{CFArray, CFArrayRef};
+    use core_foundation::base::{CFRelease, CFTypeRef, TCFType};
+    use core_foundation::boolean::kCFBooleanTrue;
+    use core_foundation::string::{CFString, CFStringRef};
+
+    use objc2::msg_send;
+    use objc2::runtime::AnyObject;
+
+    type AXUIElementRef = *const c_void;
+    type AXError = i32;
+    const AX_OK: AXError = 0;
+
+    // AX attribute / action names are NSStrings in the framework, but
+    // since CFString and NSString are toll-free bridged we just
+    // rebuild them from Rust strs as needed.
+    const K_AX_WINDOWS_ATTRIBUTE: &str = "AXWindows";
+    const K_AX_TITLE_ATTRIBUTE: &str = "AXTitle";
+    const K_AX_MINIMIZED_ATTRIBUTE: &str = "AXMinimized";
+    const K_AX_MAIN_ATTRIBUTE: &str = "AXMain";
+    const K_AX_RAISE_ACTION: &str = "AXRaise";
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        // Returns whether the calling process is trusted to use AX. A
+        // null `options` arg means "do not prompt"; passing a dict
+        // with kAXTrustedCheckOptionPrompt=true would surface the
+        // system prompt. We want a non-prompting probe so callers
+        // (search, focus) can fail fast without UI side-effects.
+        fn AXIsProcessTrustedWithOptions(options: *const c_void) -> u8;
+
+        fn AXUIElementCreateApplication(pid: c_int) -> AXUIElementRef;
+
+        fn AXUIElementCopyAttributeValue(
+            element: AXUIElementRef,
+            attribute: CFStringRef,
+            value: *mut CFTypeRef,
+        ) -> AXError;
+
+        fn AXUIElementSetAttributeValue(
+            element: AXUIElementRef,
+            attribute: CFStringRef,
+            value: CFTypeRef,
+        ) -> AXError;
+
+        fn AXUIElementPerformAction(
+            element: AXUIElementRef,
+            action: CFStringRef,
+        ) -> AXError;
+    }
+
+    /// RAII wrapper for a retained AX element. Releases the
+    /// underlying CFTypeRef on drop. Send is sound because CF
+    /// retain/release is thread-safe.
+    struct AXRef(AXUIElementRef);
+    impl AXRef {
+        /// Take ownership of a +1 retained ref (returned by Create
+        /// or Copy functions per CF naming convention). Returns None
+        /// for null pointers.
+        unsafe fn take(p: AXUIElementRef) -> Option<Self> {
+            if p.is_null() {
+                None
+            } else {
+                Some(AXRef(p))
+            }
+        }
+        fn as_raw(&self) -> AXUIElementRef {
+            self.0
+        }
+    }
+    impl Drop for AXRef {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe { CFRelease(self.0 as CFTypeRef) };
+            }
+        }
+    }
+    unsafe impl Send for AXRef {}
+
+    struct StoredWindow {
+        ax: AXRef,
+        pid: u32,
+    }
+
+    /// Side-table mapping our minted i64 handles to retained AX
+    /// refs. Initialized lazily on first enumeration. Each new
+    /// enumeration replaces the entire map; the prior entries'
+    /// AXRef Drops handle CFRelease.
+    static WINDOW_TABLE: OnceLock<Mutex<HashMap<i64, StoredWindow>>> = OnceLock::new();
+
+    fn table() -> &'static Mutex<HashMap<i64, StoredWindow>> {
+        WINDOW_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    fn ax_is_trusted() -> bool {
+        unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) != 0 }
+    }
+
+    /// Read an AX attribute as a +1 retained CFTypeRef. Caller owns.
+    unsafe fn copy_attr(element: AXUIElementRef, attr: &str) -> Option<CFTypeRef> {
+        let cf_attr = CFString::new(attr);
+        let mut out: CFTypeRef = std::ptr::null();
+        let err =
+            AXUIElementCopyAttributeValue(element, cf_attr.as_concrete_TypeRef(), &mut out);
+        if err != AX_OK || out.is_null() {
+            None
+        } else {
+            Some(out)
+        }
+    }
+
+    fn read_attr_string(element: AXUIElementRef, attr: &str) -> Option<String> {
+        unsafe {
+            let raw = copy_attr(element, attr)?;
+            // wrap_under_create_rule consumes the +1 retain.
+            let cf_str = CFString::wrap_under_create_rule(raw as CFStringRef);
+            Some(cf_str.to_string())
+        }
+    }
+
+    fn read_attr_bool(element: AXUIElementRef, attr: &str) -> Option<bool> {
+        unsafe {
+            let raw = copy_attr(element, attr)?;
+            // CFBoolean has only two singleton instances; pointer
+            // equality with kCFBooleanTrue is the standard idiom.
+            let is_true = raw as *const c_void == kCFBooleanTrue as *const c_void;
+            CFRelease(raw);
+            Some(is_true)
+        }
+    }
+
+    /// Iterate `NSWorkspace.sharedWorkspace.runningApplications` and
+    /// return (pid, localizedName) pairs. Skips our own process so
+    /// Watson doesn't list itself.
+    fn list_running_apps() -> Vec<(i32, String)> {
+        let our_pid = std::process::id() as i32;
+        let mut apps = Vec::new();
+        unsafe {
+            // [NSWorkspace sharedWorkspace] -> NSWorkspace*
+            let ws_class = objc2::class!(NSWorkspace);
+            let workspace: *mut AnyObject = msg_send![ws_class, sharedWorkspace];
+            if workspace.is_null() {
+                return apps;
+            }
+            // [workspace runningApplications] -> NSArray<NSRunningApplication*>*
+            let array: *mut AnyObject = msg_send![workspace, runningApplications];
+            if array.is_null() {
+                return apps;
+            }
+            let count: usize = msg_send![array, count];
+            for i in 0..count {
+                let app: *mut AnyObject = msg_send![array, objectAtIndex: i];
+                if app.is_null() {
+                    continue;
+                }
+                let pid: i32 = msg_send![app, processIdentifier];
+                if pid <= 0 || pid == our_pid {
+                    continue;
+                }
+                // [app localizedName] -> NSString*; can be nil for
+                // some background helpers — fall back to "unknown".
+                let name_ns: *mut AnyObject = msg_send![app, localizedName];
+                let name = if name_ns.is_null() {
+                    String::from("unknown")
+                } else {
+                    // NSString -> Rust String via UTF8String C buffer.
+                    let cstr: *const i8 = msg_send![name_ns, UTF8String];
+                    if cstr.is_null() {
+                        String::from("unknown")
+                    } else {
+                        std::ffi::CStr::from_ptr(cstr)
+                            .to_string_lossy()
+                            .into_owned()
+                    }
+                };
+                apps.push((pid, name));
+            }
+        }
+        apps
+    }
+
+    pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
+        if !ax_is_trusted() {
+            return Err(
+                "Watson does not have Accessibility permission. Grant access in \
+                 System Settings → Privacy & Security → Accessibility, then try again."
+                    .to_string(),
+            );
+        }
+
+        let mut entries = Vec::new();
+        let mut new_table: HashMap<i64, StoredWindow> = HashMap::new();
+        let mut next_handle: i64 = 1;
+
+        for (pid, app_name) in list_running_apps() {
+            let ax_app = unsafe { AXUIElementCreateApplication(pid) };
+            let ax_app_owned = match unsafe { AXRef::take(ax_app) } {
+                Some(r) => r,
+                None => continue,
+            };
+
+            // Get the windows array. Apps without windows (background
+            // daemons, Dock, Finder when no windows are open) return
+            // either an error or an empty array — both are skipped.
+            let windows_raw = match unsafe { copy_attr(ax_app_owned.as_raw(), K_AX_WINDOWS_ATTRIBUTE) } {
+                Some(p) => p,
+                None => continue,
+            };
+            let windows_array: CFArray<CFTypeRef> =
+                unsafe { CFArray::wrap_under_create_rule(windows_raw as CFArrayRef) };
+
+            for i in 0..windows_array.len() {
+                let window_ref = match windows_array.get(i) {
+                    Some(r) => *r,
+                    None => continue,
+                };
+                if window_ref.is_null() {
+                    continue;
+                }
+
+                // CFArrayGetValueAtIndex returns a borrowed (non-
+                // retained) reference. We need to retain since
+                // we're going to outlive the array.
+                let retained_window = unsafe {
+                    let _: CFTypeRef = core_foundation::base::CFRetain(window_ref);
+                    AXRef::take(window_ref as AXUIElementRef)
+                };
+                let retained_window = match retained_window {
+                    Some(r) => r,
+                    None => continue,
+                };
+
+                // Skip minimized windows (matches Win32 IsIconic
+                // filter — we'd surface them as a separate route in
+                // a follow-up if useful).
+                if read_attr_bool(retained_window.as_raw(), K_AX_MINIMIZED_ATTRIBUTE) == Some(true)
+                {
+                    continue;
+                }
+
+                let title = match read_attr_string(retained_window.as_raw(), K_AX_TITLE_ATTRIBUTE)
+                {
+                    Some(t) if !t.trim().is_empty() => t,
+                    _ => continue, // Untitled — skip, matches Win32.
+                };
+
+                let handle = next_handle;
+                next_handle += 1;
+
+                entries.push(WindowEntry {
+                    hwnd: handle,
+                    pid: pid as u32,
+                    process_name: app_name.clone(),
+                    title,
+                });
+                new_table.insert(
+                    handle,
+                    StoredWindow {
+                        ax: retained_window,
+                        pid: pid as u32,
+                    },
+                );
+            }
+        }
+
+        // Replace the side table; old entries' AXRef Drops fire here.
+        let mut t = table().lock().unwrap();
+        *t = new_table;
+
+        Ok(entries)
+    }
+
+    pub fn focus_window(hwnd: i64) -> Result<(), String> {
+        if !ax_is_trusted() {
+            return Err(
+                "Watson does not have Accessibility permission. Grant access in \
+                 System Settings → Privacy & Security → Accessibility, then try again."
+                    .to_string(),
+            );
+        }
+
+        // Look up + clone the AX ref so we can drop the lock before
+        // running AX calls (AX calls can be slow and we don't want
+        // to block other table ops). We "clone" by retaining.
+        let stored = {
+            let t = table().lock().unwrap();
+            let entry = t
+                .get(&hwnd)
+                .ok_or_else(|| format!("window {hwnd} not in current snapshot — re-search"))?;
+            let raw = entry.ax.as_raw();
+            unsafe { core_foundation::base::CFRetain(raw as CFTypeRef) };
+            (
+                unsafe { AXRef::take(raw) }.expect("retained ref non-null"),
+                entry.pid,
+            )
+        };
+        let (target, pid) = stored;
+
+        // 1. Make this window the app's main window. Some apps need
+        //    this for the subsequent raise to bring this specific
+        //    window to the front (vs. some other window of the same
+        //    app).
+        unsafe {
+            let attr = CFString::new(K_AX_MAIN_ATTRIBUTE);
+            let _ = AXUIElementSetAttributeValue(
+                target.as_raw(),
+                attr.as_concrete_TypeRef(),
+                kCFBooleanTrue as CFTypeRef,
+            );
+            // 2. Raise the window within its app's window stack.
+            let action = CFString::new(K_AX_RAISE_ACTION);
+            let raise_err =
+                AXUIElementPerformAction(target.as_raw(), action.as_concrete_TypeRef());
+            if raise_err != AX_OK {
+                return Err(format!(
+                    "AX raise failed (err {raise_err}) — window may have closed"
+                ));
+            }
+        }
+
+        // 3. Bring the owning app to the foreground. AX raise alone
+        //    won't bring an app forward across Spaces; we need
+        //    NSRunningApplication.activate for that. Failure is
+        //    non-fatal — the window is at least raised within its
+        //    own Space.
+        unsafe {
+            let cls = objc2::class!(NSRunningApplication);
+            let app: *mut AnyObject =
+                msg_send![cls, runningApplicationWithProcessIdentifier: pid as i32];
+            if !app.is_null() {
+                // NSApplicationActivateAllWindows = 1 (deprecated on
+                // 14+ but still functional and the only stable
+                // numeric option). Newer code paths use the no-arg
+                // -activate, but we keep the bitmask form for
+                // compatibility back to macOS 11.
+                let _: () = msg_send![app, activateWithOptions: 1u64];
+            }
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn ax_trusted_does_not_panic() {
+            // CI runners typically don't have AX granted to the test
+            // process; we assert only that the call doesn't panic
+            // and returns a deterministic bool.
+            let _ = ax_is_trusted();
+        }
+
+        #[test]
+        fn list_running_apps_returns_self_excluded() {
+            // The runner has at least one running app (itself, plus
+            // launchd, etc.). Verify we skip our own PID.
+            let our_pid = std::process::id() as i32;
+            let apps = list_running_apps();
+            for (pid, _) in &apps {
+                assert_ne!(*pid, our_pid, "list_running_apps must exclude Watson");
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #61 for window enumeration + focus + AX permission probe. Browser-tab enumeration and the polished permission UX are explicitly deferred to follow-up issues.

## Summary

Replaces the macOS stubs in `actions/windows.rs` with a working AX-based backend. macOS users who grant Accessibility permission can now search for and focus any visible non-minimized window of any running app.

## What's in
- `get_open_windows()`: walks `NSWorkspace.runningApplications` → `AXUIElementCreateApplication` per app → `kAXWindowsAttribute` array. Filters minimized windows + untitled windows + Watson's own PID.
- `focus_window()`: `kAXMain = true` → `kAXRaiseAction` (raises within app) → `NSRunningApplication.activate(options: 1)` (cross-Space app activation).
- AX permission probe via `AXIsProcessTrustedWithOptions(NULL)`. Untrusted callers get a clean error string: *"Watson does not have Accessibility permission. Grant access in System Settings → Privacy & Security → Accessibility, then try again."*
- Synthetic i64 handles backed by a `OnceLock<Mutex<HashMap<i64, AXRef>>>` side-table since AX elements aren't stable numeric IDs. RAII `AXRef` wrapper handles CFRelease.
- Tests for the parts that don't require AX trust (permission probe doesn't panic; running-apps list excludes self).

## What's out (separate follow-up issues)
- **Browser tabs on macOS**: AX tree walk for Safari / Chromium-family / Firefox windows to find `AXTabGroup` → `AXRadioButton`/`AXTab` children, perform `kAXPressAction`. The current `actions/browser_tabs.rs` non-Windows branch returns `Ok(vec![])`, satisfying graceful-degradation for now.
- **Polished permission UX**: deep-link to `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`, integrate with the `StartupWarning` system. This PR ships a clean error message; the dedicated UX lands in a follow-up.

## Test plan
- [x] `cargo check` on Windows — macOS code is `cfg`-gated, doesn't affect Windows build
- [ ] CI compile on macos-latest (aarch64) — depends on this run
- [ ] **Manual on a Mac** (you'll need to drive this):
  - **Permission denied path**: First launch on a clean machine. Search a window title, hit Enter — confirm the error message says to grant Accessibility in Settings.
  - **After granting access**: re-search; window rows appear. Hit Enter — target window is raised and its app comes forward.
  - **Multi-window app** (e.g., Brave with two windows, VS Code with two projects): each window appears as its own row, not collapsed.
  - **Cross-Space focus**: send a window to another Space (Mission Control); search + Enter from a different Space — confirm the focus crosses Spaces and brings the window forward.
  - **Minimized window**: should NOT appear (filtered).
  - **Watson's own window**: should NOT appear (self-PID filter).
  - **Stale handle**: search, wait, close the target window, hit Enter — confirm clean error rather than panic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)