### PR TITLE
feat(linux): browser tab switching via AT-SPI (closes #66)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -113,6 +113,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6014,8 +6039,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
  "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
  "blocking",
  "enumflags2",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -89,6 +89,123 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +292,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.3",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -378,6 +508,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -768,6 +907,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +965,27 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-iterator"
@@ -968,6 +1155,19 @@ name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1402,6 +1602,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2115,6 +2321,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2505,6 +2724,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2781,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2735,6 +2970,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +3023,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3595,6 +3855,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,6 +4017,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -4570,7 +4847,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4621,6 +4910,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4917,6 +5217,7 @@ dependencies = [
  "walkdir",
  "windows",
  "x11rb",
+ "zbus",
 ]
 
 [[package]]
@@ -5668,6 +5969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5694,6 +6005,63 @@ dependencies = [
  "quote",
  "syn 2.0.111",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -5807,4 +6175,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,12 @@ windows = { version = "0.61", features = [
 # toplevel) is a follow-up issue; in the meantime the runtime falls
 # back to an explanatory error on Wayland sessions.
 x11rb = "0.13"
+# AT-SPI is a D-Bus protocol; zbus's blocking-api feature lets us
+# call it from the synchronous search hot path without dragging
+# tokio's runtime into actions code. We use raw proxies (no `atspi`
+# crate) to keep the dependency surface small and to avoid coupling
+# to that crate's still-evolving API.
+zbus = { version = "4", default-features = false, features = ["blocking"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Accessibility (AXUIElement) FFI declared inline; this gets us the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,7 +57,7 @@ x11rb = "0.13"
 # tokio's runtime into actions code. We use raw proxies (no `atspi`
 # crate) to keep the dependency surface small and to avoid coupling
 # to that crate's still-evolving API.
-zbus = { version = "4", default-features = false, features = ["blocking"] }
+zbus = { version = "4", features = ["blocking"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Accessibility (AXUIElement) FFI declared inline; this gets us the

--- a/src-tauri/src/actions/browser_tabs.rs
+++ b/src-tauri/src/actions/browser_tabs.rs
@@ -97,17 +97,15 @@ pub use win::{focus_browser_tab, get_browser_tabs};
 #[cfg(target_os = "macos")]
 pub use mac::{focus_browser_tab, get_browser_tabs};
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(target_os = "linux")]
+pub use linux_atspi::{focus_browser_tab, get_browser_tabs};
+
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn get_browser_tabs(_hwnd: i64, _process_name: &str) -> Result<Vec<TabEntry>, String> {
-    // Linux has AT-SPI but browser support is patchy and gated
-    // behind per-browser flags / screen-reader presence — tracked
-    // as a separate issue. Until that lands, return empty so the
-    // search path stays well-behaved (window-only switcher rows
-    // still work; tabs simply don't surface).
     Ok(vec![])
 }
 
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+#[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
 pub fn focus_browser_tab(_hwnd: i64, _index: i32) -> Result<(), String> {
     Err("Browser tab switching not yet implemented on this platform".to_string())
 }
@@ -613,6 +611,384 @@ mod mac {
                         let _: () = msg_send![app, activateWithOptions: 1u64];
                     }
                 }
+                return Ok(());
+            }
+            leaf_idx += 1;
+        }
+
+        Err(format!("tab index {index} out of range"))
+    }
+}
+
+// --- Linux AT-SPI implementation ---
+//
+// AT-SPI is the Linux a11y framework — a D-Bus protocol implemented
+// by the at-spi2-core daemon. Browsers expose tab strips as
+// `PageTabList` accessibles with `PageTab` children.
+//
+// Reality of per-browser support:
+//
+// - **Firefox**: a11y is enabled by default in modern builds; the
+//   tree is populated lazily on first AT-SPI query and may be empty
+//   for ~100ms after launch. Generally reliable.
+// - **Chromium-family** (Chrome, Brave, Edge, Vivaldi, Opera, Arc):
+//   the AT-SPI bridge is gated behind `--force-renderer-accessibility`
+//   or the presence of an active screen reader (Orca). Without one of
+//   these, the renderer's a11y tree is empty even though the browser
+//   window's outer chrome (tab strip included) IS exposed. So tab
+//   enumeration usually works on Chromium; per-page content
+//   inspection wouldn't.
+//
+// We probe each browser process once per session and cache the
+// result. If the AT-SPI tree has no PageTabList for a given window,
+// subsequent calls short-circuit to empty without re-walking.
+//
+// Sync API: zbus's `blocking-api` feature gives us a synchronous
+// proxy. The search hot path is sync and we don't want to drag a
+// tokio runtime into actions code, so we make all D-Bus calls
+// blocking. Each call is local (Unix socket); typical round-trip
+// is sub-millisecond, so even a deep tree walk is fast enough for
+// the 1s TTL cache to amortize.
+
+#[cfg(target_os = "linux")]
+mod linux_atspi {
+    use super::TabEntry;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
+
+    use zbus::blocking::connection::Builder as ConnectionBuilder;
+    use zbus::blocking::{Connection, Proxy};
+    use zbus::zvariant::OwnedObjectPath;
+
+    const ATSPI_BUS: &str = "org.a11y.Bus";
+    const ATSPI_BUS_PATH: &str = "/org/a11y/bus";
+    const ATSPI_BUS_IFACE: &str = "org.a11y.Bus";
+
+    const ATSPI_REGISTRY_BUS: &str = "org.a11y.atspi.Registry";
+    const ATSPI_REGISTRY_PATH: &str = "/org/a11y/atspi/registry";
+    const ATSPI_REGISTRY_IFACE: &str = "org.a11y.atspi.Registry";
+
+    const ACCESSIBLE_IFACE: &str = "org.a11y.atspi.Accessible";
+    const ACTION_IFACE: &str = "org.a11y.atspi.Action";
+
+    /// AT-SPI Role enum (ABI-stable since AT-SPI 2.0). Sourced from
+    /// `Atspi.Role` in the GTK docs. We only need the two we filter on.
+    const ROLE_PAGE_TAB: u32 = 36;
+    const ROLE_PAGE_TAB_LIST: u32 = 37;
+
+    /// Bound the tree walk so a malformed accessible tree can't
+    /// loop us forever. Browser tab strips are at depth 2-4 from the
+    /// frame root in practice.
+    const MAX_DEPTH: u8 = 8;
+
+    thread_local! {
+        /// Per-thread connection caches. AT-SPI client connections
+        /// are cheap to keep open; reusing one across calls avoids
+        /// the bus-discovery dance on every search keystroke.
+        static SESSION_BUS: RefCell<Option<Connection>> = const { RefCell::new(None) };
+        static A11Y_BUS: RefCell<Option<Connection>> = const { RefCell::new(None) };
+
+        /// 1s TTL cache keyed by hwnd, mirroring the Windows UIA
+        /// and macOS AX modules.
+        static TAB_CACHE: RefCell<HashMap<i64, (Instant, Vec<TabEntry>)>> =
+            RefCell::new(HashMap::new());
+
+        /// Per-PID "AT-SPI exposes a tab strip for this process"
+        /// flag. Populated on first successful enumeration; once a
+        /// PID is marked unsupported (e.g. the renderer-only Chromium
+        /// case where no PageTabList shows up) we short-circuit
+        /// subsequent calls to avoid re-walking the tree.
+        static PID_SUPPORT: RefCell<HashMap<u32, bool>> =
+            RefCell::new(HashMap::new());
+    }
+    const CACHE_TTL: Duration = Duration::from_secs(1);
+
+    fn session_bus() -> Result<Connection, String> {
+        SESSION_BUS.with(|cell| {
+            if let Some(c) = cell.borrow().as_ref() {
+                return Ok(c.clone());
+            }
+            let conn = Connection::session().map_err(|e| format!("session bus: {e}"))?;
+            *cell.borrow_mut() = Some(conn.clone());
+            Ok(conn)
+        })
+    }
+
+    /// Discover and connect to the AT-SPI accessibility bus. The
+    /// session bus's `org.a11y.Bus.GetAddress` returns the address
+    /// of a separate D-Bus daemon dedicated to a11y traffic.
+    fn a11y_bus() -> Result<Connection, String> {
+        A11Y_BUS.with(|cell| {
+            if let Some(c) = cell.borrow().as_ref() {
+                return Ok(c.clone());
+            }
+            let session = session_bus()?;
+            let proxy = Proxy::new(&session, ATSPI_BUS, ATSPI_BUS_PATH, ATSPI_BUS_IFACE)
+                .map_err(|e| format!("a11y proxy: {e}"))?;
+            let address: String = proxy
+                .call("GetAddress", &())
+                .map_err(|e| format!("GetAddress: {e}"))?;
+            let conn = ConnectionBuilder::address(address.as_str())
+                .map_err(|e| format!("a11y address parse: {e}"))?
+                .build()
+                .map_err(|e| format!("a11y bus connect ({address}): {e}"))?;
+            *cell.borrow_mut() = Some(conn.clone());
+            Ok(conn)
+        })
+    }
+
+    /// Resolve the unix PID of a unique D-Bus name (e.g. `:1.123`)
+    /// via the standard `org.freedesktop.DBus.GetConnectionUnixProcessID`
+    /// RPC on the session bus.
+    fn pid_of_dbus_name(name: &str) -> Option<u32> {
+        let session = session_bus().ok()?;
+        let proxy = Proxy::new(
+            &session,
+            "org.freedesktop.DBus",
+            "/org/freedesktop/DBus",
+            "org.freedesktop.DBus",
+        )
+        .ok()?;
+        proxy.call("GetConnectionUnixProcessID", &name).ok()
+    }
+
+    /// Look up the X11 `_NET_WM_PID` for an X11 window id. We re-do
+    /// this per call rather than caching since the window switcher's
+    /// own `WindowEntry.pid` isn't plumbed through to browser_tabs.
+    /// One round-trip to the X server, ~sub-millisecond.
+    fn pid_of_window(hwnd: i64) -> Result<u32, String> {
+        if hwnd <= 0 || hwnd > u32::MAX as i64 {
+            return Err(format!("invalid X11 window id: {hwnd}"));
+        }
+        use x11rb::connection::Connection as XConnection;
+        use x11rb::protocol::xproto::{AtomEnum, ConnectionExt as _};
+        let (conn, _) = x11rb::connect(None).map_err(|e| format!("X11 connect: {e}"))?;
+        let pid_atom = conn
+            .intern_atom(false, b"_NET_WM_PID")
+            .map_err(|e| format!("intern: {e}"))?
+            .reply()
+            .map_err(|e| format!("intern reply: {e}"))?
+            .atom;
+        let reply = conn
+            .get_property(false, hwnd as u32, pid_atom, AtomEnum::CARDINAL, 0, 1)
+            .map_err(|e| format!("get_property: {e}"))?
+            .reply()
+            .map_err(|e| format!("get_property reply: {e}"))?;
+        if reply.format != 32 || reply.value.len() < 4 {
+            return Err(format!("window {hwnd:#x} has no _NET_WM_PID"));
+        }
+        let bytes = [reply.value[0], reply.value[1], reply.value[2], reply.value[3]];
+        Ok(u32::from_ne_bytes(bytes))
+    }
+
+    /// Resolve the AT-SPI Application root accessible (bus_name +
+    /// object_path) for a given OS PID by enumerating registry
+    /// applications and matching their owning unix pid.
+    fn find_app_root(pid: u32) -> Result<(String, OwnedObjectPath), String> {
+        let conn = a11y_bus()?;
+        let registry = Proxy::new(
+            &conn,
+            ATSPI_REGISTRY_BUS,
+            ATSPI_REGISTRY_PATH,
+            ATSPI_REGISTRY_IFACE,
+        )
+        .map_err(|e| format!("registry proxy: {e}"))?;
+        let apps: Vec<(String, OwnedObjectPath)> = registry
+            .call("GetApplications", &())
+            .map_err(|e| format!("GetApplications: {e}"))?;
+        for (bus_name, path) in apps {
+            if let Some(p) = pid_of_dbus_name(&bus_name) {
+                if p == pid {
+                    return Ok((bus_name, path));
+                }
+            }
+        }
+        Err(format!("no AT-SPI application registered for pid {pid}"))
+    }
+
+    /// Read an Accessible's role (u32) and child count (i32). One
+    /// round-trip per property.
+    fn role_and_child_count(
+        conn: &Connection,
+        bus_name: &str,
+        path: &OwnedObjectPath,
+    ) -> Option<(u32, i32)> {
+        let proxy = Proxy::new(conn, bus_name, path.as_str(), ACCESSIBLE_IFACE).ok()?;
+        let role: u32 = proxy.call("GetRole", &()).ok()?;
+        let count: i32 = proxy.get_property("ChildCount").ok()?;
+        Some((role, count))
+    }
+
+    fn get_child(
+        conn: &Connection,
+        bus_name: &str,
+        path: &OwnedObjectPath,
+        index: i32,
+    ) -> Option<(String, OwnedObjectPath)> {
+        let proxy = Proxy::new(conn, bus_name, path.as_str(), ACCESSIBLE_IFACE).ok()?;
+        proxy.call("GetChildAtIndex", &index).ok()
+    }
+
+    fn get_name(conn: &Connection, bus_name: &str, path: &OwnedObjectPath) -> Option<String> {
+        let proxy = Proxy::new(conn, bus_name, path.as_str(), ACCESSIBLE_IFACE).ok()?;
+        proxy.get_property::<String>("Name").ok()
+    }
+
+    /// DFS for a descendant accessible whose role is `PageTabList`.
+    fn find_tab_list(
+        conn: &Connection,
+        bus_name: &str,
+        path: OwnedObjectPath,
+        depth: u8,
+    ) -> Option<(String, OwnedObjectPath)> {
+        if depth > MAX_DEPTH {
+            return None;
+        }
+        let (role, child_count) = role_and_child_count(conn, bus_name, &path)?;
+        if role == ROLE_PAGE_TAB_LIST {
+            return Some((bus_name.to_string(), path));
+        }
+        for i in 0..child_count {
+            if let Some((cb, cp)) = get_child(conn, bus_name, &path, i) {
+                if let Some(found) = find_tab_list(conn, &cb, cp, depth + 1) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    pub fn get_browser_tabs(hwnd: i64, process_name: &str) -> Result<Vec<TabEntry>, String> {
+        let now = Instant::now();
+        let cached = TAB_CACHE.with(|c| {
+            let map = c.borrow();
+            map.get(&hwnd)
+                .filter(|(t, _)| now.duration_since(*t) < CACHE_TTL)
+                .map(|(_, tabs)| tabs.clone())
+        });
+        if let Some(tabs) = cached {
+            return Ok(tabs);
+        }
+
+        let pid = pid_of_window(hwnd)?;
+
+        // Per-pid support cache: short-circuit for processes we
+        // already know don't expose tabs over AT-SPI (Chromium
+        // without renderer-accessibility, etc.).
+        let prev_support = PID_SUPPORT.with(|c| c.borrow().get(&pid).copied());
+        if let Some(false) = prev_support {
+            return Ok(Vec::new());
+        }
+
+        let (bus_name, app_path) = match find_app_root(pid) {
+            Ok(v) => v,
+            Err(_) => {
+                PID_SUPPORT.with(|c| {
+                    c.borrow_mut().insert(pid, false);
+                });
+                TAB_CACHE.with(|c| {
+                    c.borrow_mut().insert(hwnd, (now, Vec::new()));
+                });
+                return Ok(Vec::new());
+            }
+        };
+
+        let conn = a11y_bus()?;
+        let tab_list = match find_tab_list(&conn, &bus_name, app_path, 0) {
+            Some(v) => v,
+            None => {
+                // App is registered with AT-SPI but exposes no tab
+                // strip — common for Chromium without the
+                // accessibility flag. Mark unsupported so we don't
+                // re-walk the tree on every keystroke.
+                PID_SUPPORT.with(|c| {
+                    c.borrow_mut().insert(pid, false);
+                });
+                TAB_CACHE.with(|c| {
+                    c.borrow_mut().insert(hwnd, (now, Vec::new()));
+                });
+                return Ok(Vec::new());
+            }
+        };
+
+        // Mark supported on the first successful tab-list discovery.
+        PID_SUPPORT.with(|c| {
+            c.borrow_mut().insert(pid, true);
+        });
+
+        // Enumerate tabs.
+        let (_, list_count) = match role_and_child_count(&conn, &tab_list.0, &tab_list.1) {
+            Some(v) => v,
+            None => return Ok(Vec::new()),
+        };
+        let mut tabs = Vec::with_capacity(list_count.max(0) as usize);
+        let mut leaf_idx = 0_i32;
+        for i in 0..list_count {
+            let (cb, cp) = match get_child(&conn, &tab_list.0, &tab_list.1, i) {
+                Some(v) => v,
+                None => continue,
+            };
+            // Filter children: only include ones with role PageTab.
+            // Some browsers add separators / "+" buttons.
+            let role = role_and_child_count(&conn, &cb, &cp).map(|(r, _)| r);
+            if role != Some(ROLE_PAGE_TAB) {
+                continue;
+            }
+            let name = match get_name(&conn, &cb, &cp) {
+                Some(n) if !n.trim().is_empty() => n,
+                _ => continue,
+            };
+            tabs.push(TabEntry {
+                window_hwnd: hwnd,
+                process_name: process_name.to_string(),
+                name,
+                index: leaf_idx,
+            });
+            leaf_idx += 1;
+        }
+
+        TAB_CACHE.with(|c| {
+            c.borrow_mut().insert(hwnd, (now, tabs.clone()));
+        });
+        Ok(tabs)
+    }
+
+    pub fn focus_browser_tab(hwnd: i64, index: i32) -> Result<(), String> {
+        let pid = pid_of_window(hwnd)?;
+        let (bus_name, app_path) = find_app_root(pid)?;
+        let conn = a11y_bus()?;
+        let tab_list = find_tab_list(&conn, &bus_name, app_path, 0)
+            .ok_or_else(|| String::from("no tab strip found in this window"))?;
+
+        // Re-walk to find the Nth PageTab leaf — same filter as
+        // enumeration so the index matches.
+        let (_, list_count) = role_and_child_count(&conn, &tab_list.0, &tab_list.1)
+            .ok_or_else(|| String::from("tab list inaccessible"))?;
+        let mut leaf_idx = 0_i32;
+        for i in 0..list_count {
+            let (cb, cp) = match get_child(&conn, &tab_list.0, &tab_list.1, i) {
+                Some(v) => v,
+                None => continue,
+            };
+            let role = role_and_child_count(&conn, &cb, &cp).map(|(r, _)| r);
+            if role != Some(ROLE_PAGE_TAB) {
+                continue;
+            }
+            if leaf_idx == index {
+                // AT-SPI Action interface: DoAction(0) is "click" for
+                // most accessibles; for tabs it equates to selection.
+                let action = Proxy::new(&conn, &cb, cp.as_str(), ACTION_IFACE)
+                    .map_err(|e| format!("action proxy: {e}"))?;
+                let _: bool = action
+                    .call("DoAction", &0_i32)
+                    .map_err(|e| format!("DoAction: {e}"))?;
+
+                // Bring the X11 window to the foreground so the
+                // browser is visible (the AT-SPI selection alone
+                // doesn't focus the window).
+                use crate::actions::windows;
+                let _ = windows::focus_window(hwnd);
                 return Ok(());
             }
             leaf_idx += 1;

--- a/src-tauri/src/actions/browser_tabs.rs
+++ b/src-tauri/src/actions/browser_tabs.rs
@@ -978,7 +978,7 @@ mod linux_atspi {
             if leaf_idx == index {
                 // AT-SPI Action interface: DoAction(0) is "click" for
                 // most accessibles; for tabs it equates to selection.
-                let action = Proxy::new(&conn, &cb, cp.as_str(), ACTION_IFACE)
+                let action = Proxy::new(&conn, cb.as_str(), cp.as_str(), ACTION_IFACE)
                     .map_err(|e| format!("action proxy: {e}"))?;
                 let _: bool = action
                     .call("DoAction", &0_i32)


### PR DESCRIPTION
Closes #66. Brings browser-tab parity to Linux via AT-SPI for X11 sessions. Wayland sessions degrade to window-only (matches existing behavior).

## Summary

Walks the AT-SPI accessibility tree of a browser process to find its tab strip (`PageTabList` accessible) and surfaces each `PageTab` child as a switcher row. Activation invokes `Action.DoAction(0)` on the tab and reuses the existing `focus_window` to bring the X11 window forward.

## What's in
- New `mod linux_atspi` in `actions/browser_tabs.rs`:
  - Discovers the AT-SPI bus address via session bus's `org.a11y.Bus.GetAddress`; caches both connections per thread
  - Resolves the X11 window's `_NET_WM_PID`, then matches against AT-SPI registry applications via `org.freedesktop.DBus.GetConnectionUnixProcessID`
  - Depth-bounded DFS (8 levels) for role `PageTabList` (AT-SPI role 37)
  - Tab labels via the Accessible `Name` property
  - Activation via `Action.DoAction(0)` + existing `windows::focus_window`
  - 1s TTL cache + per-PID support cache (so processes without exposed tab strips don't get re-walked)
- `zbus = "4"` added under `cfg(target_os = "linux")` with the `blocking` feature — keeps the search hot path sync, no tokio-runtime gymnastics in actions code

## Reality of per-browser support (documented in #66)
- **Firefox**: a11y enabled by default in modern builds; lazy first-query may return empty for ~100ms after launch
- **Chromium-family** (Chrome / Brave / Edge / Vivaldi / Opera / Arc): the browser-frame AT-SPI tree (including tab strip) is exposed even without screen-reader presence, so tab enum works. Renderer/page content would be empty without `--force-renderer-accessibility`, but we don't need that for tabs.
- **Wayland sessions**: AT-SPI works (D-Bus is display-server-agnostic) but `focus_window` returns the same explanatory error as today; the result is silent degradation to window-only

## Test plan
- [x] `cargo check` on Windows — Linux code is cfg-gated, doesn't affect Windows build
- [ ] CI compile on ubuntu-22.04 — depends on this run
- [ ] **Manual on a Linux X11 session** (you'll need to drive this):
  - Open Firefox with 3+ tabs; search a tab title — confirm tab rows appear; Enter switches the tab and brings Firefox forward
  - Open Chrome / Brave with 3+ tabs; same test — confirm Chromium tab strip is enumerated
  - Run with `XDG_SESSION_TYPE=wayland` set — confirm tab rows do NOT appear (empty), no error toast
  - Browser without accessibility (e.g. an old build) — confirm empty result, no error
  - Stale handle (close window between search + Enter) — confirm clean error rather than panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)