### PR TITLE
feat(macos): startup banner + deep-link for AX permission

### DIFF
--- a/src-tauri/src/actions/windows.rs
+++ b/src-tauri/src/actions/windows.rs
@@ -862,7 +862,7 @@ mod macos {
         WINDOW_TABLE.get_or_init(|| Mutex::new(HashMap::new()))
     }
 
-    fn ax_is_trusted() -> bool {
+    pub(crate) fn ax_is_trusted() -> bool {
         unsafe { AXIsProcessTrustedWithOptions(std::ptr::null()) != 0 }
     }
 
@@ -1180,9 +1180,9 @@ mod macos {
     }
 }
 
-/// Re-export of the cross-module AX accessor used by
-/// `actions::browser_tabs`. The `mod macos` itself is private; this
-/// `pub(crate) use` makes the lookup function reachable from other
-/// modules in the crate without exposing the module's internals.
+/// Re-export of the cross-module AX accessors used by
+/// `actions::browser_tabs` and `lib.rs`. The `mod macos` itself is
+/// private; this `pub(crate) use` makes the relevant items reachable
+/// from other modules in the crate without exposing internals.
 #[cfg(target_os = "macos")]
-pub(crate) use macos::{lookup_window_ax, WindowAXHandle};
+pub(crate) use macos::{ax_is_trusted, lookup_window_ax, WindowAXHandle};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -976,6 +976,55 @@ fn open_config_folder() -> Result<(), String> {
     open::that(&dir).map_err(|e| e.to_string())
 }
 
+/// macOS-only deep-link to the Accessibility pane in System Settings.
+/// Action target for the "Grant access" button on the AX-permission
+/// banner. The `x-apple.systempreferences:` scheme has been stable
+/// since 10.10; on Linux/Windows this command is a no-op error so
+/// the frontend can call it unconditionally without platform checks.
+#[tauri::command]
+fn open_accessibility_settings() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let url = "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+        open::that(url).map_err(|e| e.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err(String::from(
+            "Accessibility permission is a macOS-only concept",
+        ))
+    }
+}
+
+/// Re-probe macOS Accessibility trust. If the user just granted
+/// access in System Settings, the AX subsystem updates immediately
+/// — no app restart required. On success, also clears the
+/// startup-warning banner so the UI reflects the new state without
+/// the user manually dismissing it. Returns the new trust state.
+#[tauri::command]
+fn recheck_accessibility_permission(state: State<AppState>) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        let trusted = actions::windows::ax_is_trusted();
+        if trusted {
+            state.startup_warnings.clear_accessibility_permission_denied();
+        } else {
+            // Re-record (idempotent via fixed id) so a stale dismissal
+            // by the user — followed by a deny — re-surfaces the
+            // banner.
+            state
+                .startup_warnings
+                .record_accessibility_permission_denied();
+        }
+        trusted
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = state;
+        true
+    }
+}
+
 /// WAT-404: open the OS file browser at `path`'s parent and (where
 /// supported) select the file. Used by the per-result Cmd+K menu's
 /// "Reveal in folder" action.
@@ -1081,6 +1130,22 @@ pub fn run() {
             notifications::Severity::Warning,
             "Clipboard filter errors",
             &format!("{} pattern(s) failed to compile: {}", pattern_errors.len(), pattern_errors.join("; ")),
+        );
+    }
+
+    // macOS only: Accessibility permission is required for the window
+    // and browser-tab switcher. Probe non-prompting at startup and
+    // surface a banner if denied — the user grants once in System
+    // Settings and re-probes via the banner's "Re-check" button
+    // without restarting Watson.
+    #[cfg(target_os = "macos")]
+    if !actions::windows::ax_is_trusted() {
+        startup_warnings.record_accessibility_permission_denied();
+        notifications.push(
+            notifications::Severity::Warning,
+            "Accessibility permission needed",
+            "Watson needs Accessibility access for the window + browser-tab switcher. \
+             Grant it in System Settings → Privacy & Security → Accessibility.",
         );
     }
 
@@ -1216,6 +1281,8 @@ pub fn run() {
             get_startup_warnings,
             dismiss_startup_warning,
             open_config_folder,
+            open_accessibility_settings,
+            recheck_accessibility_permission,
             reveal_file,
             get_reserved_prefixes
         ])

--- a/src-tauri/src/warnings.rs
+++ b/src-tauri/src/warnings.rs
@@ -32,6 +32,11 @@ pub enum StartupWarningKind {
     /// as regex. The valid patterns still apply; the user sees which
     /// ones they need to fix.
     InvalidClipboardFilter,
+    /// macOS only: the Accessibility permission needed for the window
+    /// + browser-tab switcher hasn't been granted. Surfaced eagerly
+    /// at startup so the user can grant it once instead of hitting
+    /// the same error repeatedly from the search hot path.
+    AccessibilityPermissionDenied,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,7 +138,32 @@ impl StartupWarnings {
             ),
         });
     }
+
+    /// Record that macOS Accessibility permission isn't granted. Idempotent
+    /// via a fixed id so repeated calls don't stack banners. Pair with
+    /// `clear_accessibility_permission_denied` after a successful re-probe.
+    pub fn record_accessibility_permission_denied(&self) {
+        let id = ACCESSIBILITY_DENIED_ID.to_string();
+        let _ = self.dismiss(&id);
+        self.push(StartupWarning {
+            id,
+            kind: StartupWarningKind::AccessibilityPermissionDenied,
+            message: String::from(
+                "Watson needs Accessibility access to switch between windows and browser tabs. \
+                 Grant access in System Settings → Privacy & Security → Accessibility, then \
+                 click \"Re-check\".",
+            ),
+        });
+    }
+
+    /// Remove the AX-permission warning. Called after the user grants
+    /// access and Watson re-probes successfully.
+    pub fn clear_accessibility_permission_denied(&self) -> bool {
+        self.dismiss(ACCESSIBILITY_DENIED_ID)
+    }
 }
+
+const ACCESSIBILITY_DENIED_ID: &str = "accessibility-permission-denied";
 
 #[cfg(test)]
 mod tests {
@@ -248,5 +278,30 @@ mod tests {
         w.record_settings_from_newer_version(2, 1);
         w.record_settings_from_newer_version(2, 1);
         assert_eq!(w.list().len(), 1);
+    }
+
+    #[test]
+    fn record_accessibility_permission_denied_idempotent() {
+        // Repeated calls (eg. startup probe + re-check probe with the
+        // same denied state) should not stack banners.
+        let w = StartupWarnings::new();
+        w.record_accessibility_permission_denied();
+        w.record_accessibility_permission_denied();
+        assert_eq!(w.list().len(), 1);
+        assert!(matches!(
+            w.list()[0].kind,
+            StartupWarningKind::AccessibilityPermissionDenied
+        ));
+    }
+
+    #[test]
+    fn clear_accessibility_permission_denied_removes_the_banner() {
+        let w = StartupWarnings::new();
+        w.record_accessibility_permission_denied();
+        assert_eq!(w.list().len(), 1);
+        assert!(w.clear_accessibility_permission_denied());
+        assert!(w.list().is_empty());
+        // Clearing when nothing is recorded is a no-op (returns false).
+        assert!(!w.clear_accessibility_permission_denied());
     }
 }

--- a/src/components/StartupWarningBanner.tsx
+++ b/src/components/StartupWarningBanner.tsx
@@ -98,6 +98,10 @@ function WarningRow({
         </button>
       )}
 
+      {warning.kind === 'accessibility_permission_denied' && (
+        <AccessibilityPermissionActions />
+      )}
+
       <button
         type="button"
         onClick={onDismiss}
@@ -116,5 +120,49 @@ function WarningRow({
         </svg>
       </button>
     </li>
+  );
+}
+
+/**
+ * macOS-only AX permission actions: opens the Accessibility pane in
+ * System Settings, then re-probes on the user's "Re-check" click. The
+ * re-probe clears its own banner on success via
+ * `clear_accessibility_permission_denied` in the backend, so we just
+ * call `loadStartupWarnings` to refresh the list.
+ */
+function AccessibilityPermissionActions() {
+  const { loadStartupWarnings } = useAppStore();
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          invoke('open_accessibility_settings').catch((err) =>
+            console.error('Failed to open Accessibility settings:', err),
+          )
+        }
+        className="text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap"
+      >
+        Grant access
+      </button>
+      <button
+        type="button"
+        onClick={async () => {
+          try {
+            await invoke<boolean>('recheck_accessibility_permission');
+          } catch (err) {
+            console.error('Failed to re-check Accessibility permission:', err);
+          } finally {
+            // Refresh either way — backend clears the warning when
+            // trusted, re-records when still denied, so the banner
+            // list always reflects current state after this call.
+            loadStartupWarnings();
+          }
+        }}
+        className="text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap"
+      >
+        Re-check
+      </button>
+    </>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,8 @@ export interface FileSearchSettings {
 export type StartupWarningKind =
   | 'shortcut_unavailable'
   | 'settings_from_newer_version'
-  | 'invalid_clipboard_filter';
+  | 'invalid_clipboard_filter'
+  | 'accessibility_permission_denied';
 
 // WAT-406: notifications drawer
 


### PR DESCRIPTION
Polish for the macOS switcher (#61) and browser-tab support (#65). On a fresh install the user hits the Accessibility permission wall the first time they search a window — this PR makes that wall navigable instead of silent.

## Behavior change
At startup on macOS, if `AXIsProcessTrustedWithOptions(NULL)` returns false, an amber banner appears:

> Watson needs Accessibility access to switch between windows and browser tabs. Grant access in System Settings → Privacy & Security → Accessibility, then click "Re-check".

Two action buttons:
- **Grant access** → opens the Accessibility pane via `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`
- **Re-check** → re-probes AX trust without restarting Watson; banner auto-dismisses on success

## Implementation
- `StartupWarningKind::AccessibilityPermissionDenied` variant + idempotent `record_/clear_` helpers (matches the existing settings/shortcut/clipboard pattern).
- `actions::windows::macos::ax_is_trusted` re-exported as `pub(crate)`.
- Two Tauri commands: `open_accessibility_settings` and `recheck_accessibility_permission`. Both are no-op stubs on non-macOS so the frontend can call them unconditionally.
- Setup pushes the banner only on macOS; mirrors into the WAT-406 notifications drawer so the history sticks after dismissal.

## Test plan
- [x] Backend: `cargo test warnings::` — record idempotency + clear cycle (12/12 pass)
- [x] Frontend: `npm test --run` — 103/103 pass; the new banner kind is additive
- [ ] CI Linux + Windows + macOS compile (depends on this run)
- [ ] **Manual on a Mac** (you'll drive this):
  - First launch on a clean profile (no AX grant yet) → confirm the amber banner appears
  - Click "Grant access" → System Settings should open at the Accessibility pane
  - Toggle Watson on, return to the app, click "Re-check" → banner should disappear
  - Search a window title → switcher should now work without restarting Watson
  - Toggle Watson off in Settings, click "Re-check" → banner should re-record (still denied)
  - Dismiss the banner manually → banner closes; remains absent until next launch
  - Linux / Windows: confirm no banner ever appears (cfg-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)