### PR TITLE
feat(linux): Wayland window switcher via wlr-foreign-toplevel

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -867,6 +867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,7 +3025,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.12.1",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -3182,6 +3188,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -5240,9 +5255,81 @@ dependencies = [
  "toml 0.8.2",
  "urlencoding",
  "walkdir",
+ "wayland-client",
+ "wayland-protocols-wlr",
  "windows",
  "x11rb",
  "zbus",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.10.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -48,9 +48,7 @@ windows = { version = "0.61", features = [
 [target.'cfg(target_os = "linux")'.dependencies]
 # X11 client for window enumeration + focus on X11 sessions. Default
 # features include the pure-Rust `rust_connection` so we don't pick up
-# a libxcb build-time dependency. Wayland support (wlr-foreign-
-# toplevel) is a follow-up issue; in the meantime the runtime falls
-# back to an explanatory error on Wayland sessions.
+# a libxcb build-time dependency.
 x11rb = "0.13"
 # AT-SPI is a D-Bus protocol; zbus's blocking-api feature lets us
 # call it from the synchronous search hot path without dragging
@@ -58,6 +56,13 @@ x11rb = "0.13"
 # crate) to keep the dependency surface small and to avoid coupling
 # to that crate's still-evolving API.
 zbus = { version = "4", features = ["blocking"] }
+# Wayland client + wlr-foreign-toplevel-management protocol. This
+# unlocks the switcher on wlroots-based compositors (Sway, Hyprland,
+# river, Wayfire). GNOME/Mutter and KDE/KWin do not implement this
+# protocol; on those compositors the runtime returns a clear
+# "compositor unsupported" error rather than silent emptiness.
+wayland-client = "0.31"
+wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # Accessibility (AXUIElement) FFI declared inline; this gets us the

--- a/src-tauri/src/actions/windows.rs
+++ b/src-tauri/src/actions/windows.rs
@@ -373,19 +373,41 @@ mod linux {
     pub fn get_open_windows() -> Result<Vec<WindowEntry>, String> {
         match detect_backend() {
             Backend::X11 => x11::get_open_windows(),
-            Backend::Wayland(_) => Ok(Vec::new()),
+            Backend::Wayland(_) => match wayland::get_open_windows() {
+                Ok(entries) => Ok(entries),
+                // Compositor-unsupported is a soft failure: return empty so
+                // the search picker doesn't show an error toast on every
+                // keystroke. The user sees a hint via the focus path's
+                // explicit error message if they try to act on a stale
+                // entry.
+                Err(WaylandError::CompositorUnsupported) => Ok(Vec::new()),
+                Err(WaylandError::Other(msg)) => Err(msg),
+            },
         }
     }
 
     pub fn focus_window(hwnd: i64) -> Result<(), String> {
         match detect_backend() {
             Backend::X11 => x11::focus_window(hwnd),
-            Backend::Wayland(name) => Err(format!(
-                "Window switching is not supported on {name} (Wayland session). \
-                 Log in with an X11 session to use the switcher; \
-                 Wayland support is tracked in a separate issue."
-            )),
+            Backend::Wayland(name) => match wayland::focus_window(hwnd) {
+                Ok(()) => Ok(()),
+                Err(WaylandError::CompositorUnsupported) => Err(format!(
+                    "Window switching not supported on {name} (Wayland). \
+                     Compositor doesn't advertise the wlr-foreign-toplevel \
+                     protocol; works on Sway, Hyprland, river, Wayfire."
+                )),
+                Err(WaylandError::Other(msg)) => Err(msg),
+            },
         }
+    }
+
+    enum WaylandError {
+        /// Compositor advertised no zwlr_foreign_toplevel_manager_v1
+        /// global. GNOME/Mutter and KDE/KWin land here; users on those
+        /// compositors won't get the switcher until those projects
+        /// adopt the protocol or we add a per-compositor backend.
+        CompositorUnsupported,
+        Other(String),
     }
 
     /// Resolve a process name from a PID via `/proc/<pid>/comm`,
@@ -672,6 +694,271 @@ mod linux {
                 .configure_window(target, &ConfigureWindowAux::new().stack_mode(StackMode::ABOVE));
 
             conn.flush().map_err(|e| format!("flush: {e}"))?;
+            Ok(())
+        }
+    }
+
+    /// wlr-foreign-toplevel-management-unstable-v1 client.
+    ///
+    /// Per-call connection: open a wayland socket, bind the manager and
+    /// a seat, run a handful of roundtrips to drain the bootstrap event
+    /// burst, harvest toplevels, disconnect. Local Unix-socket so the
+    /// total cost is sub-50ms even on a session with dozens of windows.
+    ///
+    /// Identity: synthetic i64 derived from a SipHash of (app_id, title).
+    /// We don't keep wayland proxies alive across calls, so on focus we
+    /// re-enumerate, hash each toplevel, and activate the match. If two
+    /// windows happen to share the same app_id+title (rare), the first
+    /// one wins — acceptable for v1.
+    mod wayland {
+        use super::super::WindowEntry;
+        use super::WaylandError;
+        use std::collections::HashMap;
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle};
+        use wayland_client::protocol::{wl_registry, wl_seat};
+        use wayland_protocols_wlr::foreign_toplevel::v1::client::{
+            zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1},
+            zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
+        };
+
+        const FOREIGN_TOPLEVEL_VERSION: u32 = 3;
+
+        #[derive(Default, Clone)]
+        struct ToplevelInfo {
+            title: String,
+            app_id: String,
+            minimized: bool,
+            done: bool,
+            closed: bool,
+        }
+
+        #[derive(Default)]
+        struct State {
+            manager: Option<ZwlrForeignToplevelManagerV1>,
+            seat: Option<wl_seat::WlSeat>,
+            // Keyed by the toplevel handle's protocol id so we can
+            // associate per-toplevel events back to a single entry.
+            toplevels: HashMap<u32, (ZwlrForeignToplevelHandleV1, ToplevelInfo)>,
+            registry_done: bool,
+        }
+
+        impl State {
+            fn list_done_toplevels(&self) -> Vec<&ToplevelInfo> {
+                self.toplevels
+                    .values()
+                    .filter(|(_, info)| info.done && !info.closed && !info.minimized)
+                    .filter(|(_, info)| !info.title.trim().is_empty())
+                    .map(|(_, info)| info)
+                    .collect()
+            }
+        }
+
+        impl Dispatch<wl_registry::WlRegistry, ()> for State {
+            fn event(
+                state: &mut Self,
+                registry: &wl_registry::WlRegistry,
+                event: wl_registry::Event,
+                _: &(),
+                _: &Connection,
+                qh: &QueueHandle<Self>,
+            ) {
+                use wl_registry::Event;
+                if let Event::Global { name, interface, version } = event {
+                    if interface == ZwlrForeignToplevelManagerV1::interface().name {
+                        let v = version.min(FOREIGN_TOPLEVEL_VERSION);
+                        let mgr = registry.bind::<ZwlrForeignToplevelManagerV1, _, _>(name, v, qh, ());
+                        state.manager = Some(mgr);
+                    } else if interface == wl_seat::WlSeat::interface().name && state.seat.is_none() {
+                        let seat = registry.bind::<wl_seat::WlSeat, _, _>(name, version.min(7), qh, ());
+                        state.seat = Some(seat);
+                    }
+                }
+                state.registry_done = true;
+            }
+        }
+
+        impl Dispatch<wl_seat::WlSeat, ()> for State {
+            fn event(
+                _: &mut Self,
+                _: &wl_seat::WlSeat,
+                _: wl_seat::Event,
+                _: &(),
+                _: &Connection,
+                _: &QueueHandle<Self>,
+            ) {
+                // We don't need seat capabilities/name; binding it is
+                // sufficient for the activate request.
+            }
+        }
+
+        impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for State {
+            fn event(
+                state: &mut Self,
+                _: &ZwlrForeignToplevelManagerV1,
+                event: zwlr_foreign_toplevel_manager_v1::Event,
+                _: &(),
+                _: &Connection,
+                _: &QueueHandle<Self>,
+            ) {
+                use zwlr_foreign_toplevel_manager_v1::Event;
+                if let Event::Toplevel { toplevel } = event {
+                    let id = toplevel.id().protocol_id();
+                    state
+                        .toplevels
+                        .insert(id, (toplevel, ToplevelInfo::default()));
+                }
+            }
+        }
+
+        impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for State {
+            fn event(
+                state: &mut Self,
+                handle: &ZwlrForeignToplevelHandleV1,
+                event: zwlr_foreign_toplevel_handle_v1::Event,
+                _: &(),
+                _: &Connection,
+                _: &QueueHandle<Self>,
+            ) {
+                use zwlr_foreign_toplevel_handle_v1::Event;
+                let id = handle.id().protocol_id();
+                let entry = match state.toplevels.get_mut(&id) {
+                    Some(e) => e,
+                    None => return,
+                };
+                let info = &mut entry.1;
+                match event {
+                    Event::Title { title } => info.title = title,
+                    Event::AppId { app_id } => info.app_id = app_id,
+                    Event::State { state: state_arr } => {
+                        // The state array contains 4-byte values per
+                        // wlr-foreign-toplevel state enum. State 1 is
+                        // "minimized".
+                        info.minimized = state_arr.chunks_exact(4).any(|c| {
+                            u32::from_ne_bytes([c[0], c[1], c[2], c[3]])
+                                == zwlr_foreign_toplevel_handle_v1::State::Minimized as u32
+                        });
+                    }
+                    Event::Done => info.done = true,
+                    Event::Closed => info.closed = true,
+                    _ => {}
+                }
+            }
+        }
+
+        /// Hash an (app_id, title) pair into a stable i64 within JSON's
+        /// safe-integer range (53 bits). Used as the synthetic window
+        /// handle. Collisions across (app_id, title) pairs map two
+        /// windows to one row — rare and acceptable for v1.
+        fn hash_handle(app_id: &str, title: &str) -> i64 {
+            let mut h = DefaultHasher::new();
+            app_id.hash(&mut h);
+            "::".hash(&mut h);
+            title.hash(&mut h);
+            // Mask to 53 bits so the value round-trips through
+            // JSON's f64 safe-integer range without precision loss.
+            ((h.finish() & ((1u64 << 53) - 1)) as i64).max(1)
+        }
+
+        /// Bring up a wayland connection, bind the wlr manager + seat,
+        /// run roundtrips until all toplevels have fired their `done`
+        /// event. Returns the populated State for the caller to read.
+        fn snapshot() -> Result<(Connection, EventQueue<State>, State), WaylandError> {
+            let conn = Connection::connect_to_env()
+                .map_err(|e| WaylandError::Other(format!("wayland connect: {e}")))?;
+            let mut event_queue = conn.new_event_queue::<State>();
+            let qh = event_queue.handle();
+            let display = conn.display();
+            let _registry = display.get_registry(&qh, ());
+
+            let mut state = State::default();
+            // Roundtrip 1: receive Global events, bind manager + seat.
+            event_queue
+                .roundtrip(&mut state)
+                .map_err(|e| WaylandError::Other(format!("wayland roundtrip 1: {e}")))?;
+
+            if state.manager.is_none() {
+                return Err(WaylandError::CompositorUnsupported);
+            }
+
+            // Roundtrip 2: manager fires Toplevel events for each existing
+            // toplevel. After this, state.toplevels has handles registered
+            // but per-toplevel events haven't fired yet.
+            event_queue
+                .roundtrip(&mut state)
+                .map_err(|e| WaylandError::Other(format!("wayland roundtrip 2: {e}")))?;
+
+            // Roundtrip 3: each handle fires its title/app_id/state/done
+            // sequence. After this, every entry should have done=true.
+            event_queue
+                .roundtrip(&mut state)
+                .map_err(|e| WaylandError::Other(format!("wayland roundtrip 3: {e}")))?;
+
+            // Some compositors are lazy and emit `done` only after a
+            // grace period; one more roundtrip catches stragglers.
+            event_queue
+                .roundtrip(&mut state)
+                .map_err(|e| WaylandError::Other(format!("wayland roundtrip 4: {e}")))?;
+
+            Ok((conn, event_queue, state))
+        }
+
+        pub fn get_open_windows() -> Result<Vec<WindowEntry>, WaylandError> {
+            let (_conn, _eq, state) = snapshot()?;
+            let entries = state
+                .list_done_toplevels()
+                .iter()
+                .map(|info| WindowEntry {
+                    hwnd: hash_handle(&info.app_id, &info.title),
+                    // Wayland surfaces don't expose pid via this protocol;
+                    // 0 is our convention for "unknown".
+                    pid: 0,
+                    process_name: if info.app_id.is_empty() {
+                        "unknown".to_string()
+                    } else {
+                        info.app_id.clone()
+                    },
+                    title: info.title.clone(),
+                })
+                .collect();
+            Ok(entries)
+        }
+
+        pub fn focus_window(hwnd: i64) -> Result<(), WaylandError> {
+            let (_conn, mut event_queue, state) = snapshot()?;
+            let seat = state
+                .seat
+                .as_ref()
+                .ok_or_else(|| WaylandError::Other(String::from("no wl_seat advertised")))?;
+
+            // Find the toplevel whose hash matches.
+            let target = state
+                .toplevels
+                .values()
+                .filter(|(_, info)| info.done && !info.closed)
+                .find(|(_, info)| hash_handle(&info.app_id, &info.title) == hwnd);
+
+            let (handle, _) = match target {
+                Some(t) => t,
+                None => {
+                    return Err(WaylandError::Other(format!(
+                        "window {hwnd} not in current snapshot — re-search"
+                    )))
+                }
+            };
+
+            handle.activate(seat);
+            // If the toplevel was minimized we also need to unset that
+            // state for the activate to actually surface it. The protocol
+            // exposes `unset_minimized` for exactly this.
+            handle.unset_minimized();
+            // Flush the pending requests; we don't need to wait for
+            // additional events.
+            event_queue
+                .roundtrip(&mut State::default())
+                .map_err(|e| WaylandError::Other(format!("wayland flush: {e}")))?;
             Ok(())
         }
     }


### PR DESCRIPTION
Polish for the Linux switcher (#62). The X11 backend covers users on legacy sessions, but Ubuntu 24.04, Fedora, and Pop!_OS 24.04 default to Wayland — those users currently get an empty switcher. This PR adds a Wayland backend for **wlroots-based compositors** (Sway, Hyprland, river, Wayfire) via the `wlr-foreign-toplevel-management-unstable-v1` protocol.

GNOME/Mutter and KDE/KWin don't implement this protocol; on those compositors the runtime returns a clear "compositor unsupported" message rather than silent emptiness.

## Behavior matrix
| Session | Compositor | Result |
|---|---|---|
| X11 (any DE) | n/a | Full switcher (PR #63) |
| Wayland | Sway / Hyprland / river / Wayfire | Full switcher (this PR) |
| Wayland | GNOME / KDE / others | Compositor-unsupported error on focus; empty enum on search |

## Implementation
- Per-call wayland connection (sub-50ms; local Unix socket): bind `zwlr_foreign_toplevel_manager_v1` and `wl_seat`, drive 4 event roundtrips to drain the bootstrap burst, harvest toplevels, disconnect.
- `Dispatch` impls for the four interfaces involved (`WlRegistry`, `WlSeat`, manager, handle).
- Synthetic i64 handle = SipHash of (app_id, title), masked to 53 bits so it round-trips through JSON safely.
- Filter: drop closed, drop minimized, drop empty titles — matches the X11 / Win32 visibility filters.
- `focus_window`: re-snapshots, finds the matching hash, calls `activate(seat)` + `unset_minimized` so hidden targets surface.

## Test plan
- [x] `cargo check` on Windows — Linux code is `cfg`-gated; deps resolve cleanly
- [ ] CI compile on ubuntu-22.04 (depends on this run)
- [ ] **Manual on a wlroots compositor** (Sway / Hyprland / river — you'll need to drive this):
  - Open 3+ apps with windows, search a window title — confirm rows appear with title + app_id as process_name
  - Hit Enter — target window comes forward
  - Minimized window — should NOT appear (filtered)
  - Multi-window app (two terminals, two browser windows) — each should appear; confirm hash collisions don't merge them in normal usage
  - Activate from a different workspace — confirm the workspace switches as needed
- [ ] **Manual on GNOME/KDE Wayland**: search returns no Wayland switcher rows; if a stale handle exists, focus shows the explanatory error
- [ ] **Manual on X11 (any DE)**: still works as before — Wayland code path is gated by `XDG_SESSION_TYPE=wayland`

## What's still out of scope
- GNOME Wayland switcher (would need a shell extension; not happening here)
- KDE Wayland switcher (would need `org.kde.KWin/Scripting` D-Bus calls; brittle, deferred)
- Browser tabs on Wayland (the AT-SPI path from #66 already works on Wayland; the X11 dependency for window focus is a separate gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)