### PR TITLE
fix(ui): four UX quick cuts (Phase 1B preamble)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,15 +15,24 @@ import { NotificationsDrawer } from './components/NotificationsDrawer';
 import { useAppStore } from './stores/app';
 import type { WebSearch } from './types';
 
-// Watson's iconic bowler hat
+// Watson's iconic bowler hat. Body fills use `currentColor` driven by
+// theme-aware text utilities so the silhouette stays legible in dark
+// mode (the original hardcoded gray-700/gray-800 fills disappeared
+// against the dark `--background`). The hat band keeps the amber
+// accent across both themes.
 function WatsonLogo() {
   return (
-    <svg className="w-8 h-8" viewBox="0 0 32 32" fill="none">
-      {/* Bowler hat */}
-      <ellipse cx="16" cy="22" rx="14" ry="3" className="fill-gray-700" />
-      <path d="M6 22c0-8 4-14 10-14s10 6 10 14" className="fill-gray-800" />
-      <ellipse cx="16" cy="8" rx="6" ry="2" className="fill-gray-700" />
-      {/* Hat band */}
+    <svg
+      className="w-8 h-8 text-gray-700 dark:text-gray-200"
+      viewBox="0 0 32 32"
+      fill="none"
+      aria-hidden="true"
+    >
+      {/* Bowler hat — `currentColor` follows the parent's text color */}
+      <ellipse cx="16" cy="22" rx="14" ry="3" fill="currentColor" />
+      <path d="M6 22c0-8 4-14 10-14s10 6 10 14" fill="currentColor" />
+      <ellipse cx="16" cy="8" rx="6" ry="2" fill="currentColor" />
+      {/* Hat band — accent color, same in both themes */}
       <rect x="8" y="18" width="16" height="2" rx="0.5" className="fill-amber-600" />
     </svg>
   );
@@ -602,19 +611,37 @@ function App() {
     return () => document.removeEventListener('contextmenu', handleContextMenu);
   }, []);
 
-  // Apply theme
+  // Apply theme. When mode === 'system', also subscribe to OS-level
+  // theme changes so flipping macOS / Windows light/dark while Watson
+  // is open propagates immediately — previously the effect only ran
+  // on mount and on settings change, so a runtime OS theme flip was
+  // ignored until the next launch.
   useEffect(() => {
     if (!settings) return;
 
     const { mode } = settings.theme;
     const root = document.documentElement;
+    const mql = window.matchMedia('(prefers-color-scheme: dark)');
 
-    if (mode === 'system') {
-      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      root.classList.toggle('dark', isDark);
-    } else {
-      root.classList.toggle('dark', mode === 'dark');
+    const applyMode = () => {
+      if (mode === 'system') {
+        root.classList.toggle('dark', mql.matches);
+      } else {
+        root.classList.toggle('dark', mode === 'dark');
+      }
+    };
+
+    applyMode();
+
+    if (mode !== 'system') {
+      // Explicit light/dark choice — no need to listen to the OS.
+      return;
     }
+    // Track OS preference changes only while in 'system' mode. Older
+    // Safari uses addListener; addEventListener is the modern path
+    // and supported by all Tauri-target browsers (Chromium / WebKit).
+    mql.addEventListener('change', applyMode);
+    return () => mql.removeEventListener('change', applyMode);
   }, [settings?.theme.mode]);
 
   return (

--- a/src/components/NoteEditor.tsx
+++ b/src/components/NoteEditor.tsx
@@ -101,7 +101,19 @@ export function NoteEditor() {
     <div className="p-4 border-t border-[var(--border)]" onKeyDown={handleKeyDown}>
       <div className="flex justify-between items-center mb-3">
         <h3 className="font-semibold flex items-center gap-2">
-          <span className="text-lg">📝</span>
+          <svg
+            className="w-4 h-4 text-purple-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="16" y1="13" x2="8" y2="13" />
+            <line x1="16" y1="17" x2="8" y2="17" />
+          </svg>
           {currentNote ? 'Edit Note' : 'New Note'}
         </h3>
         <div className="flex gap-2">

--- a/src/components/ResultsList.tsx
+++ b/src/components/ResultsList.tsx
@@ -10,8 +10,8 @@ function EmptyState() {
         <p className="font-medium text-gray-500 text-xs">Quick Tips</p>
         <div className="space-y-0.5 text-xs">
           <p><span className="text-blue-400 font-mono">g query</span> - Google search</p>
-          <p><span className="text-blue-400 font-mono">n</span> - Notes • <span className="text-blue-400 font-mono">f</span> - Files</p>
-          <p><span className="text-blue-400 font-mono">cb</span> - Clipboard • <span className="text-blue-400 font-mono">s</span> - Scratchpad</p>
+          <p><span className="text-blue-400 font-mono">n&nbsp;</span> - Notes • <span className="text-blue-400 font-mono">f&nbsp;</span> - Files</p>
+          <p><span className="text-blue-400 font-mono">cb&nbsp;</span> - Clipboard • <span className="text-blue-400 font-mono">`</span> - Scratchpad</p>
         </div>
       </div>
     </div>

--- a/src/components/Scratchpad.tsx
+++ b/src/components/Scratchpad.tsx
@@ -28,7 +28,17 @@ export function Scratchpad() {
     <div className="p-4 border-t border-[var(--border)]">
       <div className="flex justify-between items-center mb-3">
         <h3 className="font-semibold flex items-center gap-2">
-          <span className="text-lg">📋</span>
+          <svg
+            className="w-4 h-4 text-amber-500"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path d="M12 20h9" />
+            <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+          </svg>
           Scratchpad
         </h3>
         <div className="flex gap-2">


### PR DESCRIPTION
Lifts the four lowest-hanging items from #76 (Phase 1B) so v1.6.2 ships visible "we're consolidating" signal without waiting for the bigger token/density work.

## Changes

1. **Stale Quick Tips fixed** — \`src/components/ResultsList.tsx\`. Empty state taught deprecated bare-letter shortcuts (\`n\`, \`f\`, \`s\`); those were removed in v1.5.1. Now teaches \`n \`, \`f \`, \`cb \`, and backtick for scratchpad — actual current behavior.
2. **Emoji removed from panel headers** — \`NoteEditor.tsx\` and \`Scratchpad.tsx\`. The 📝 / 📋 emoji clashed with the SVG-only icon family used everywhere else. Replaced with theme-aware SVGs.
3. **WatsonLogo legible in dark mode** — \`src/App.tsx\`. Hardcoded \`fill-gray-700/800\` made the logo nearly invisible against the dark background. Switched to \`currentColor\` + \`dark:text-gray-200\` so the silhouette stays readable across themes.
4. **\`prefers-color-scheme\` listener wired** — \`src/App.tsx\`. OS theme changes now propagate to Watson immediately when \`theme.mode === 'system'\`; previously required restart.

## Test plan
- [x] \`npm test --run\` — 103/103 frontend tests pass
- [ ] CI on Mac/Win/Linux compile
- [ ] Manual: dark mode logo legibility on Windows + macOS
- [ ] Manual: flip OS theme while Watson is open; UI updates without restart
- [ ] Manual: panel headers (NoteEditor, Scratchpad) render the new SVGs

Closes the four checkboxes at the top of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)