### PR TITLE
feat(ui): window chrome + activation motion (Phase 1B)

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,11 +17,11 @@
         "height": 400,
         "resizable": false,
         "decorations": false,
-        "transparent": false,
+        "transparent": true,
         "alwaysOnTop": true,
         "center": true,
         "visible": true,
-        "shadow": false
+        "shadow": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -619,6 +619,42 @@ function App() {
     return () => document.removeEventListener('contextmenu', handleContextMenu);
   }, []);
 
+  // Activation animation: plays the spring-in entrance whenever the
+  // Watson window gains focus (hotkey show + initial mount). Uses the
+  // Web Animations API so each call plays from the start without
+  // CSS-restart hacks. Timing + easing mirror the `--motion-*` tokens
+  // (180ms / ease-out); kept here in JS so React re-renders don't
+  // re-trigger it (only window focus events do).
+  const appContainerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const playActivation = () => {
+      const el = appContainerRef.current;
+      if (!el) return;
+      el.animate(
+        [
+          { opacity: 0, transform: 'scale(0.98) translateY(-4px)' },
+          { opacity: 1, transform: 'scale(1) translateY(0)' },
+        ],
+        {
+          duration: 180,
+          easing: 'cubic-bezier(0.16, 1, 0.3, 1)',
+          fill: 'both',
+        },
+      );
+    };
+    // Fire once on initial mount (Watson is visible from launch).
+    playActivation();
+    // And re-fire whenever the window regains focus (hotkey-show).
+    const win = getCurrentWindow();
+    let unlisten: undefined | (() => void);
+    win.listen('tauri://focus', playActivation).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+
   // Apply theme. When mode === 'system', also subscribe to OS-level
   // theme changes so flipping macOS / Windows light/dark while Watson
   // is open propagates immediately — previously the effect only ran
@@ -653,7 +689,10 @@ function App() {
   }, [settings?.theme.mode]);
 
   return (
-    <div className="bg-[var(--background)] text-[var(--foreground)] rounded-xl overflow-hidden border border-[var(--border)] shadow-2xl">
+    <div
+      ref={appContainerRef}
+      className="bg-[var(--background)] text-[var(--foreground)] rounded-[14px] overflow-hidden border border-[var(--border)] shadow-[var(--shadow-elevated)]"
+    >
       {/* Header - draggable */}
       <div
         data-tauri-drag-region

--- a/src/index.css
+++ b/src/index.css
@@ -186,11 +186,16 @@
   --input-bg:   var(--surface-sunken);
 }
 
+/* The Tauri window is now `transparent: true`, so the html/body need
+ * to render transparent — the visible surface (with its rounded
+ * corners + drop shadow) lives on the inner App container. This is
+ * the standard floating-launcher pattern (Spotlight / Raycast) and
+ * lets the OS show a real soft drop-shadow behind the rounded
+ * content instead of a flat rectangle. */
 html, body, #root {
-  background: var(--surface-base);
+  background: transparent;
   margin: 0;
   padding: 0;
-  border-radius: var(--radius-lg);
   overflow: hidden;
 }
 
@@ -232,4 +237,29 @@ body {
 
 .animate-fade-in {
   animation: fadeIn var(--motion-duration-base) var(--motion-ease-out) forwards;
+}
+
+/* =====================================================================
+ * Activation animation
+ *
+ * Plays once when the Watson window receives focus (i.e. on hotkey
+ * show, not on every keystroke). Mirrors the Raycast / Spotlight
+ * "spring-in" feel: subtle scale (0.98 → 1.0) + a small downward
+ * settle (-4px → 0) + opacity fade. Triggered imperatively from
+ * App.tsx via the Web Animations API, so each show plays from the
+ * start without CSS-restart hacks.
+ *
+ * The keyframe is defined here so the curve / timing is part of the
+ * design system; the trigger lives in JS so the UI can decide when
+ * to fire (window focus, not every render).
+ * ===================================================================== */
+@keyframes activate {
+  from {
+    opacity: 0;
+    transform: scale(0.98) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
 }


### PR DESCRIPTION
First user-visible Phase 1B change. Builds on the design tokens from #79 (this PR is targeted at `main` but assumes #79 lands first; rebase will be trivial).

## What changes
**Window chrome** — Watson now floats on the desktop with real depth instead of looking like a flat rectangle:

- `tauri.conf.json`: `transparent: true` + `shadow: true`
- The visible launcher surface (rounded corners + shadow) lives on the inner App container; html/body are transparent
- `shadow-[var(--shadow-elevated)]` consumes the new shadow token (`0 24px 48px -12px ...` paired with a tighter inner stroke)
- `rounded-[14px]` matches `--radius-lg` from the token system

**Activation motion** — the launcher now feels alive when summoned:

- New `@keyframes activate` in `index.css` documents the entrance as part of the design system
- `App.tsx` plays the animation via Web Animations API on (a) initial mount and (b) every `tauri://focus` event (hotkey-show)
- 180ms `cubic-bezier(0.16, 1, 0.3, 1)` — matches `--motion-duration-base` + `--motion-ease-out`. Restrained, not bouncy (per DESIGN.md decision filter)
- Scale 0.98 → 1.0 + translateY(-4px) → 0 + opacity fade

## What stays unchanged
Everything else. No component restructuring, no row density change, no theme behavior change. The animation only fires on window focus events — React re-renders don't re-trigger it.

## Test plan
- [x] `npm run build` clean, `npm test --run` 103/103 pass
- [ ] CI cross-platform compile
- [ ] **Manual on Windows**: hide + reshow Watson via Alt+Space — confirm spring-in animation. Confirm window has visible drop shadow against the desktop. Confirm rounded corners are clean (no flat-rectangle clipping).
- [ ] **Manual on macOS**: same as Windows. Bonus: confirm the OS-level shadow doesn't double up with the CSS shadow (might need to reduce one or the other).
- [ ] **Manual on Linux X11**: confirm transparency works on whatever WM you're using (transparency support varies).
- [ ] **Sanity**: dragging the header still works (transparent window + drag-region should be fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
