### PR TITLE
docs(design): commit to bar + workspace-window form factor

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -64,6 +64,57 @@ macOS. Spotlight ate the floor (clipboard, snippets, app intents are
 free in macOS 26 Tahoe), so we have to live above the floor — Scenes
 and MCP are above it.
 
+## Form factor — bar for dispatch, windows for sustained work
+
+Watson is **two surfaces, not one**:
+
+1. **The launcher bar** — the existing floating window. Grows
+   vertically to fit results, dismisses on Escape / blur,
+   alwaysOnTop. Stays as the home for *transient dispatch*: app
+   launching, file/note search, calculator, web search, snippets,
+   clipboard pick, window/tab switching, system commands, and (in
+   Phase 2b) MCP tool *invocation*. Width stays 600-800px depending
+   on monitor; never grows horizontally to host content.
+
+2. **Workspace windows** — purpose-built secondary Tauri windows
+   for *sustained work*. Settings, Scene authoring, MCP chat
+   (scrollback + multi-turn), Extensions browse/configure, future
+   long-form Note editing. Standard chrome (titled, resizable,
+   persistent state). Each is summoned explicitly — by typing
+   `>scenes` / `>settings` / `ask` in the launcher, by clicking
+   an affordance, or via its own hotkey if it earns one.
+
+This pattern matches what Raycast and Alfred actually shipped
+once they grew beyond pure launcher. Raycast keeps its bar narrow
+and ships [Notes](https://manual.raycast.com/notes) /
+[AI Chat](https://manual.raycast.com/ai) /
+[Settings](https://manual.raycast.com/settings) as separate windows.
+Alfred draws the same line: bar for invocation, Workflow Editor
++ Clipboard Viewer in their own windows. The companion research
+(May 2026) confirmed this is the dominant 2026 pattern; pure-bar
+launchers (LaunchBar, PowerToys CmdPal) lose ground as content
+breadth grows, and "workspace + palette" inversions (Linear, VS
+Code) are workspace apps with palettes — the wrong mirror image
+for a cross-app launcher.
+
+What we're explicitly **rejecting**:
+
+- ❌ **One window forever.** Cramming Scenes authoring + MCP chat
+  + full Extensions browser into a 600×grow-to-fit dismiss-on-blur
+  window would betray the launcher loop and the sustained-work
+  loop simultaneously.
+- ❌ **Workspace + palette inversion.** Watson's identity is
+  *cross-app dispatch*. A permanent canvas would make us a workspace
+  app that happens to have a launcher, which is Linear / VS Code's
+  shape — wrong for our positioning.
+- ❌ **Detail-pane stretching to host authoring.** Phase 1C's
+  detail pane is for *preview* of the focused result (note
+  content, file metadata, browser tab URL). It is not the home for
+  Scene editing or chat scrollback — those are workspace work.
+
+The migration is staged so the launcher loop never breaks while
+workspace-mode is introduced. See Phase 2a in the roadmap below.
+
 ## Architectural shape
 
 The audit identified Watson as a *dispatcher with hardcoded providers,
@@ -210,11 +261,36 @@ What we're explicitly **not** doing:
 - ❌ Inline result editing — too much surface area for v1.
   Revisit after Scenes ship.
 
-### Phase 2a — Scenes (first flagship, target: 3-4 weeks after Phase 1)
+### Phase 2a — Scenes + Workspace window (first flagship, target: 3-4 weeks after Phase 1)
 
-A **Scene** is a named, ordered list of Actions. Activating a Scene
-runs its actions sequentially with a small inter-step delay. Built on
-the new `Action` handler registry from Phase 1 — Scenes are
+Two things ship together in this phase because they need each
+other: **Scenes** (the feature) and **the workspace window**
+(the home where sustained Watson work lives from now on).
+
+**Workspace window** — a second Tauri window, hidden by default,
+summoned explicitly. Holds:
+- The Scene editor (this phase)
+- Settings (migrated out of the launcher panel cascade — that
+  cramming was the canary that proved we needed this)
+- MCP chat (Phase 2b)
+- Extensions browser + per-extension config (Phase 2c)
+
+The workspace window is a **real desktop window** with title bar,
+resize, persistent size + position, and standard `Cmd+W` close
+behavior. The launcher bar stays floating, alwaysOnTop, dismiss-on-
+blur, untouched.
+
+**Summon paths**:
+- Type `>settings` / `>scenes` / `>extensions` in the launcher (Enter
+  hides launcher, foregrounds workspace, navigates to that tab)
+- Click an affordance — the gear icon currently opens cramped in-bar
+  Settings; redirect to workspace
+- Reserved hotkey for power users: `Alt+Shift+Space` opens workspace
+  directly (the launcher hotkey stays `Alt+Space`)
+
+**Scene** — a named, ordered list of Actions. Activating a Scene
+runs its actions sequentially with a small inter-step delay. Built
+on the new `Action` handler registry from Phase 1 — Scenes are
 *compositions* of actions, not a parallel pipeline.
 
 V1 scope:
@@ -222,25 +298,33 @@ V1 scope:
 - Scene resource: `id`, `name`, `steps: [Action]`, persisted to SQLite
 - Action types supported in V1: `LaunchApp`, `OpenUrl`, `FocusWindow`,
   `RunSystemCommand`. (No conditionals, no loops, no inputs.)
-- Surfacing: Scenes appear in search by name (e.g. "Start Work")
-- Authoring: a dedicated Settings panel for create/edit/delete + a
-  command-palette `scene save <name>` that captures current open
-  windows and apps as a Scene
+- **Surfacing in launcher**: Scenes appear in search by name (e.g.
+  "Start Work"). Enter activates the Scene (runs its steps).
+- **Authoring in workspace**: dedicated tab with create/edit/delete
+  + reorder of steps. Plus a command-palette `scene save <name>`
+  in the launcher that captures current open windows + apps as a
+  Scene seed, then opens the workspace for refinement.
 - Cross-platform: works on Mac/Win identically; Linux best-effort
-  (Wayland window focus may not chain reliably)
+  (Wayland window focus may not chain reliably).
 
 Why this is the right first flagship: visceral demo, uses
 already-shipped action types, validates the Action registry by
-composing it.
+composing it, AND establishes the workspace window so Phase 2b
+(MCP chat) lands without re-litigating form factor.
 
 ### Phase 2b — MCP host (second flagship, target: 8-12 weeks after Phase 1)
 
-- New result kind: `Ask` (or `>` route reuse) opens a chat surface
+- New launcher route (`ask`) opens the **workspace window's chat
+  tab** — sustained scrollback, multi-turn, `@server.tool`
+  mentions. Never lives in the floating bar (the dismiss-on-blur
+  loop would destroy chat context).
 - MCP client connects to local stdio MCP servers from a config file
-- `@server.tool` mentions in chat let Claude call tools
 - BYO Anthropic/OpenAI API key — no SaaS dependency
 - Watson ships a `@watson` MCP server that exposes our own actions
   (LaunchApp, FocusWindow, etc.) as tools, dogfooding the design
+- Quick MCP tool *invocation* (firing one tool with arguments) can
+  still happen from the launcher bar for power users — the heavy
+  conversational surface lives in the workspace.
 
 ### Phase 2c — Extension API (target: after MCP lands)
 
@@ -283,6 +367,13 @@ When evaluating a feature proposal:
    animations on every keystroke / row-focus creates perceived lag.
    Reserve motion for window show/hide, panel mount, accept toasts,
    and other discrete state transitions.
+7. **Does it belong in the bar or the workspace window?** If the
+   feature requires sustained focus (writing more than a sentence,
+   reading scrollback, multi-step authoring, browsing/configuring),
+   it belongs in the workspace window. If it's transient dispatch
+   (search → action → done in <5s), it belongs in the bar. When in
+   doubt, prototype in the workspace — the bar is the constrained
+   real estate; promoting *into* it should require justification.
 
 ## Process notes
 


### PR DESCRIPTION
Captures the form-factor direction decided after the May 2026 paired analysis (architect-agent codebase audit + 2026 competitive research). The strategy memo lives in DESIGN.md; this PR is the commitment to direction.

## TL;DR
Watson is **two surfaces**:
- **Launcher bar** — the existing floating window. Stays as transient dispatch (apps, files, snippets, clipboard pick, calc, web search, window/tab switch, system commands, MCP tool *invocation*).
- **Workspace window** — new secondary Tauri window for sustained work. Holds Settings, Scenes editor (Phase 2a), MCP chat (Phase 2b), Extensions browser (Phase 2c), future long-form note editing.

This is the same shape Raycast and Alfred actually shipped once they grew beyond pure launcher. Confirmed by the companion competitive research as the dominant 2026 pattern.

## What changes in DESIGN.md
- **New "Form factor" section** before "Architectural shape" — commits to bar+workspace, rejects three other patterns with reasoning
- **Phase 2a updated** — now ships Scenes editor AND the workspace window together (workspace becomes the new home for Settings the same release)
- **Phase 2b updated** — MCP chat lands in the workspace from day one
- **Decision filter rule #7 added** — "does it belong in the bar or the workspace?" Sustained focus → workspace; transient dispatch → bar; default-to-workspace when in doubt

## Why this PR is small
Pure documentation. No code changes. The actual workspace-window implementation lands in Phase 2a alongside Scenes (issue #74).

## What this enables
- Phase 2a (#74) Scene authoring no longer has to cram into the bar
- Phase 2b MCP chat has scrollback + multi-turn from day one
- Settings can finally leave the cramped 350px panel
- The "five mutually-exclusive panel booleans" smell from the original audit gets resolved by *moving panels out* rather than just refactoring them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
