### PR TITLE
refactor(search): introduce ResultProvider trait + first migration (Phase 1A)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,8 +25,9 @@ use snippets::SnippetsManager;
 use warnings::{StartupWarning, StartupWarnings};
 use db::{AppEntry, Database};
 use indexers::{get_indexer, AppIndexer};
-use search::dispatch::{classify_prefix_route, match_web_search, Route, SubQuery, WebSearchMatch};
-use search::url_builder::build_web_search_url;
+use search::dispatch::{classify_prefix_route, Route, SubQuery};
+use search::provider::ResultProvider;
+use search::providers::web_search::WebSearchProvider;
 use search::{ResultType, SearchAction, SearchEngine, SearchResult};
 use std::sync::{Arc, RwLock};
 use tauri::{Manager, State};
@@ -408,29 +409,16 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
 
     let mut items: Vec<SearchResult> = Vec::new();
 
-    // Web search keyword match. Classification lives in search::dispatch;
-    // URL construction (scheme allowlist + {instance} validation + {query}
-    // encoding) lives in search::url_builder. A builder error (bad scheme,
-    // bad instance) silently skips the result — same policy as NeedsInstance.
-    if let WebSearchMatch::Matched { index, subquery } =
-        match_web_search(&query, &settings.web_searches)
-    {
-        let ws = &settings.web_searches[index];
-        if let Ok(url) = build_web_search_url(&ws.url, ws.instance.as_deref(), &subquery) {
-            items.push(SearchResult {
-                id: format!("web:{}", ws.keyword),
-                name: format!("{}: {}", ws.name, subquery),
-                description: "Web Search".to_string(),
-                icon: ws.icon.clone(),
-                result_type: ResultType::WebSearch,
-                score: 10000,
-                frecency_score: 0.0,
-                preview: None,
-                pinned: false,
-                action: SearchAction::OpenUrl { url },
-            });
+    // Phase 1A: web-search keyword matching now flows through a
+    // `ResultProvider` impl. Same external behavior — classification +
+    // URL construction reuse the existing helpers — but the
+    // dispatcher no longer hand-rolls the SearchResult struct.
+    items.extend(
+        WebSearchProvider {
+            configs: &settings.web_searches,
         }
-    }
+        .search(&query),
+    );
 
     // WAT-301: add snippets whose trigger/name matches the query. Runs
     // as a regular search-pipeline contributor alongside apps and web —

--- a/src-tauri/src/search/mod.rs
+++ b/src-tauri/src/search/mod.rs
@@ -1,4 +1,6 @@
 pub mod dispatch;
+pub mod provider;
+pub mod providers;
 pub mod ranking;
 pub mod url_builder;
 

--- a/src-tauri/src/search/provider.rs
+++ b/src-tauri/src/search/provider.rs
@@ -1,0 +1,113 @@
+//! Result-provider trait — Phase 1A substrate.
+//!
+//! Goal: every searchable thing (apps, files, notes, snippets, windows,
+//! tabs, calculator, web searches, system commands, scenes-future,
+//! captures-future) becomes one `impl ResultProvider`. The dispatcher
+//! in `lib.rs::search` iterates a registry instead of hand-coding a
+//! bespoke `SearchResult { ... }` block per kind.
+//!
+//! This first cut keeps the trait minimal and synchronous. Async
+//! providers (notes, file_search) will need a parallel `AsyncResultProvider`
+//! or an `async_trait` migration in a follow-up — handling that here
+//! would inflate this PR's scope and the existing hand-coded async paths
+//! work as-is.
+//!
+//! Lifetime model: providers borrow whatever app state they need for
+//! the duration of one `search()` call. Construct them inside the
+//! dispatcher per query, drop after results are collected. No long-
+//! lived state in the provider itself; that lives in `AppState`.
+
+use crate::search::SearchResult;
+
+/// A source of search results.
+///
+/// Implementations should:
+/// - Return *their own* matches against the query (filtering / fuzzy
+///   ranking). The dispatcher does NOT re-rank across providers; each
+///   provider is responsible for the score it puts on its results.
+/// - Be cheap to construct — they are built per call.
+/// - Not panic on empty / malformed queries; return an empty Vec.
+///
+/// Sync only for v1. Async providers stay hand-coded in the
+/// dispatcher pending a follow-up trait split.
+pub trait ResultProvider {
+    /// Stable identifier used in logs / diagnostics. Should be a
+    /// short snake_case slug ("web_search", "system_command",
+    /// "calculator").
+    fn name(&self) -> &'static str;
+
+    /// Run the provider against the query, returning its results.
+    /// Caller appends these to a combined `Vec<SearchResult>`.
+    fn search(&self, query: &str) -> Vec<SearchResult>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::search::{ResultType, SearchAction, SearchResult};
+
+    /// Minimal in-test provider: returns one fixed result if the
+    /// query equals "match", else empty. Validates the dispatcher
+    /// can hold and call providers through a trait object.
+    struct StubProvider;
+
+    impl ResultProvider for StubProvider {
+        fn name(&self) -> &'static str {
+            "stub"
+        }
+        fn search(&self, query: &str) -> Vec<SearchResult> {
+            if query == "match" {
+                vec![SearchResult {
+                    id: "stub:1".into(),
+                    name: "Stub match".into(),
+                    description: String::new(),
+                    icon: None,
+                    result_type: ResultType::SystemCommand,
+                    score: 100,
+                    frecency_score: 0.0,
+                    preview: None,
+                    pinned: false,
+                    action: SearchAction::RunCommand {
+                        command: "noop".into(),
+                    },
+                }]
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    #[test]
+    fn name_is_stable() {
+        let p = StubProvider;
+        assert_eq!(p.name(), "stub");
+        assert_eq!(p.name(), p.name());
+    }
+
+    #[test]
+    fn empty_query_returns_empty_vec_without_panic() {
+        let p = StubProvider;
+        assert!(p.search("").is_empty());
+    }
+
+    #[test]
+    fn match_returns_results() {
+        let p = StubProvider;
+        let results = p.search("match");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, "stub:1");
+    }
+
+    #[test]
+    fn provider_works_through_dyn_dispatch() {
+        // The dispatcher will hold providers as
+        // `Box<dyn ResultProvider>`; verify trait-object dispatch
+        // works.
+        let providers: Vec<Box<dyn ResultProvider>> = vec![Box::new(StubProvider)];
+        let mut combined = Vec::new();
+        for p in &providers {
+            combined.extend(p.search("match"));
+        }
+        assert_eq!(combined.len(), 1);
+    }
+}

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -1,0 +1,16 @@
+//! Concrete `ResultProvider` implementations.
+//!
+//! Each existing result kind in the search dispatcher migrates here
+//! one at a time. The dispatcher in `lib.rs::search` calls each
+//! provider in turn and collects the merged results.
+//!
+//! Migration order (smallest to largest, validating the trait shape
+//! before tackling the more complex providers):
+//! 1. `web_search` — pure config, no I/O, no DB
+//! 2. system commands, calculator (sync, contained)
+//! 3. apps, snippets (sync with state borrow)
+//! 4. windows, tabs (cross-platform FFI surface)
+//! 5. async providers (notes, file_search) — needs trait-async
+//!    decision
+
+pub mod web_search;

--- a/src-tauri/src/search/providers/web_search.rs
+++ b/src-tauri/src/search/providers/web_search.rs
@@ -1,0 +1,118 @@
+//! Web-search keyword provider.
+//!
+//! Surfaces a result when the query starts with a configured web-
+//! search keyword (e.g. `g rust async` matches Google's `g` and
+//! produces an "Open in Google" row). Classification + URL building
+//! reuse the existing helpers in `search::dispatch` and
+//! `search::url_builder`; this provider just packages them as a
+//! `ResultProvider` impl so the dispatcher in `lib.rs::search` can
+//! drop the bespoke struct-literal block.
+//!
+//! Lifetime: borrows a slice of `WebSearch` configs for one call's
+//! duration. Constructed inside `lib.rs::search` per query.
+
+use crate::config::settings::WebSearch;
+use crate::search::dispatch::{match_web_search, WebSearchMatch};
+use crate::search::provider::ResultProvider;
+use crate::search::url_builder::build_web_search_url;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// The numeric score web-search results carry into the dispatcher.
+/// Above the recents-bonus floor (10000) so a known keyword surfaces
+/// at the top of mixed result lists; below the calculator
+/// short-circuit (100000) which doesn't go through this path anyway.
+const WEB_SEARCH_SCORE: i64 = 10_000;
+
+pub struct WebSearchProvider<'a> {
+    pub configs: &'a [WebSearch],
+}
+
+impl<'a> ResultProvider for WebSearchProvider<'a> {
+    fn name(&self) -> &'static str {
+        "web_search"
+    }
+
+    fn search(&self, query: &str) -> Vec<SearchResult> {
+        let WebSearchMatch::Matched { index, subquery } = match_web_search(query, self.configs)
+        else {
+            return Vec::new();
+        };
+        let ws = &self.configs[index];
+
+        // URL construction can fail on bad scheme or missing
+        // {instance}; treat both as "skip the result" rather than
+        // surfacing an error — the same policy the prior hand-coded
+        // path used (lib.rs::search before the refactor).
+        let url = match build_web_search_url(&ws.url, ws.instance.as_deref(), &subquery) {
+            Ok(u) => u,
+            Err(_) => return Vec::new(),
+        };
+
+        vec![SearchResult {
+            id: format!("web:{}", ws.keyword),
+            name: format!("{}: {}", ws.name, subquery),
+            description: "Web Search".to_string(),
+            icon: ws.icon.clone(),
+            result_type: ResultType::WebSearch,
+            score: WEB_SEARCH_SCORE,
+            frecency_score: 0.0,
+            preview: None,
+            pinned: false,
+            action: SearchAction::OpenUrl { url },
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(name: &str, keyword: &str, url: &str) -> WebSearch {
+        WebSearch {
+            name: name.into(),
+            keyword: keyword.into(),
+            url: url.into(),
+            icon: None,
+            requires_setup: false,
+            instance: None,
+        }
+    }
+
+    #[test]
+    fn no_match_returns_empty() {
+        let configs = vec![cfg("Google", "g", "https://google.com/?q={query}")];
+        let p = WebSearchProvider { configs: &configs };
+        assert!(p.search("hello world").is_empty());
+    }
+
+    #[test]
+    fn match_returns_one_result_with_open_url_action() {
+        let configs = vec![cfg("Google", "g", "https://google.com/?q={query}")];
+        let p = WebSearchProvider { configs: &configs };
+        let results = p.search("g rust async");
+        assert_eq!(results.len(), 1);
+        let r = &results[0];
+        assert_eq!(r.id, "web:g");
+        assert_eq!(r.name, "Google: rust async");
+        assert!(matches!(
+            r.action,
+            SearchAction::OpenUrl { ref url } if url.contains("rust")
+        ));
+    }
+
+    #[test]
+    fn malformed_url_template_is_silently_skipped() {
+        // build_web_search_url rejects non-http(s) schemes — the prior
+        // path (and this provider) treats that as "no result", not as
+        // an error to surface.
+        let configs = vec![cfg("Bad", "b", "javascript:alert({query})")];
+        let p = WebSearchProvider { configs: &configs };
+        assert!(p.search("b foo").is_empty());
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let p = WebSearchProvider { configs: &[] };
+        assert_eq!(p.name(), "web_search");
+    }
+}


### PR DESCRIPTION
First slice of the Phase 1A architecture refactor (closes part of #73). Establishes the `ResultProvider` substrate without touching the rest of the dispatcher yet — small, reviewable, sets the pattern that subsequent PRs follow.

## What lands
- **New trait** `search::provider::ResultProvider` — the contract every searchable kind will implement once migration completes. Sync for v1; async kinds get a parallel decision later
- **First concrete impl** `WebSearchProvider` (in `search::providers::web_search`) — moves the SearchResult struct construction out of `lib.rs::search` into the provider while reusing the existing `match_web_search` + `build_web_search_url` helpers
- **Dispatcher migration** for the web-search block only — `lib.rs::search` now calls `provider.search(&query)` for that one path; everything else is unchanged
- **8 new tests**: 4 trait-level (name stability, empty-query, dyn-dispatch through trait object), 4 provider-level (no-match, full-match, malformed-template skip, name)

## What does NOT change
- External behavior: same score, same id format, same skip-on-malformed-url policy
- Other result kinds (apps, files, notes, snippets, windows, tabs, calculator, system commands) — still hand-coded in the dispatcher
- The dispatcher is NOT yet a registry loop. That lands once enough providers have migrated to make the loop meaningful

## Migration roadmap (set in `providers/mod.rs` so it's discoverable from the code)
1. **web_search ← THIS PR**
2. system_command, calculator
3. apps, snippets
4. windows, browser_tabs
5. notes, file_search (after async-trait decision)

Each step its own PR.

## Test plan
- [x] `cargo test --lib` — 357/357 pass (8 new)
- [x] `npm test --run` — 103/103 pass (no frontend change)
- [x] `cargo check` clean
- [ ] CI cross-platform compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
