### PR TITLE
refactor(search): migrate snippets to ResultProvider (Phase 1A slice 2)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ use db::{AppEntry, Database};
 use indexers::{get_indexer, AppIndexer};
 use search::dispatch::{classify_prefix_route, Route, SubQuery};
 use search::provider::ResultProvider;
+use search::providers::snippets::SnippetsProvider;
 use search::providers::web_search::WebSearchProvider;
 use search::{ResultType, SearchAction, SearchEngine, SearchResult};
 use std::sync::{Arc, RwLock};
@@ -237,19 +238,6 @@ fn calculation_result(calc: calculator::Calculation) -> SearchResult {
     }
 }
 
-/// WAT-301: first-line preview of a snippet's expansion for the
-/// description row. Collapses multi-line expansions into a single
-/// line and truncates with an ellipsis so long snippets still fit.
-fn snippet_preview(expansion: &str) -> String {
-    let first_line = expansion.lines().next().unwrap_or("");
-    let clipped: String = first_line.chars().take(80).collect();
-    if first_line.chars().count() > 80 || expansion.contains('\n') {
-        format!("{clipped}…")
-    } else {
-        clipped
-    }
-}
-
 /// WAT-306: dispatch for the `>` prefix. `>` alone returns every command
 /// in its registered order; `>foo` (or `> foo`) filters aliases by
 /// case-insensitive substring match. Runs exclusively — no apps, web
@@ -420,30 +408,16 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         .search(&query),
     );
 
-    // WAT-301: add snippets whose trigger/name matches the query. Runs
-    // as a regular search-pipeline contributor alongside apps and web —
+    // Phase 1A: snippets via `ResultProvider`. WAT-301 — runs as a
+    // regular search-pipeline contributor alongside apps and web,
     // no special prefix. Users who want scoped lookup can use a
     // `;`-prefixed trigger by convention.
-    if let Ok(snippets) = state.snippets.search(&query) {
-        for snippet in snippets {
-            items.push(SearchResult {
-                // Highlight the trigger so the user can see how they'd
-                // type next time without opening Settings.
-                id: snippet.id.clone(),
-                name: format!("{}  —  {}", snippet.trigger, snippet.name),
-                description: snippet_preview(&snippet.expansion),
-                icon: Some("snippet".to_string()),
-                result_type: ResultType::Snippet,
-                // Between web (10000) and apps (0) so snippets surface
-                // reliably when triggered but don't swamp app matches.
-                score: 8000,
-                frecency_score: 0.0,
-                preview: None,
-                pinned: false,
-                action: SearchAction::PasteSnippet { expansion: snippet.expansion },
-            });
+    items.extend(
+        SnippetsProvider {
+            manager: &state.snippets,
         }
-    }
+        .search(&query),
+    );
 
     // Add apps
     if !query.contains(' ') || items.is_empty() {

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -13,4 +13,5 @@
 //! 5. async providers (notes, file_search) — needs trait-async
 //!    decision
 
+pub mod snippets;
 pub mod web_search;

--- a/src-tauri/src/search/providers/snippets.rs
+++ b/src-tauri/src/search/providers/snippets.rs
@@ -1,0 +1,115 @@
+//! User-snippet provider.
+//!
+//! Surfaces text-expansion snippets whose trigger or name matches the
+//! query. Reuses `SnippetsManager::search` for the underlying lookup
+//! (DB-backed, ranks by trigger-prefix → name-substring); this
+//! provider just packages the matches as `SearchResult`s.
+//!
+//! Lifetime: borrows `&SnippetsManager` for one call's duration.
+//! Constructed inside `lib.rs::search` per query.
+
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+use crate::snippets::SnippetsManager;
+
+/// Score snippets land on. Sits above web-search (10000-floor for
+/// keyword matches) is intentional? No — snippets sit at 8000 so
+/// they surface reliably when their trigger matches but don't
+/// swamp app launchers when both share the prefix space. Match
+/// the prior hand-coded value.
+const SNIPPET_SCORE: i64 = 8_000;
+
+/// First-line preview of a snippet's expansion for the description
+/// row. Collapses multi-line expansions into a single line and
+/// truncates with an ellipsis so long snippets still fit.
+fn snippet_preview(expansion: &str) -> String {
+    let first_line = expansion.lines().next().unwrap_or("");
+    let clipped: String = first_line.chars().take(80).collect();
+    if first_line.chars().count() > 80 || expansion.contains('\n') {
+        format!("{clipped}…")
+    } else {
+        clipped
+    }
+}
+
+pub struct SnippetsProvider<'a> {
+    pub manager: &'a SnippetsManager,
+}
+
+impl<'a> ResultProvider for SnippetsProvider<'a> {
+    fn name(&self) -> &'static str {
+        "snippets"
+    }
+
+    fn search(&self, query: &str) -> Vec<SearchResult> {
+        // SnippetsManager::search returns Result; treat errors as
+        // "no results" — same policy the prior hand-coded path used.
+        // A real DB error already gets logged via the manager's own
+        // error path; surfacing it here would dump a stack trace into
+        // the user's search bar.
+        let snippets = match self.manager.search(query) {
+            Ok(s) => s,
+            Err(_) => return Vec::new(),
+        };
+
+        snippets
+            .into_iter()
+            .map(|snippet| SearchResult {
+                id: snippet.id.clone(),
+                // Trigger first so the user can see what to type next
+                // time without opening Settings.
+                name: format!("{}  —  {}", snippet.trigger, snippet.name),
+                description: snippet_preview(&snippet.expansion),
+                icon: Some("snippet".to_string()),
+                result_type: ResultType::Snippet,
+                score: SNIPPET_SCORE,
+                frecency_score: 0.0,
+                preview: None,
+                pinned: false,
+                action: SearchAction::PasteSnippet {
+                    expansion: snippet.expansion,
+                },
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snippet_preview_single_short_line_unchanged() {
+        assert_eq!(snippet_preview("hello"), "hello");
+    }
+
+    #[test]
+    fn snippet_preview_long_single_line_truncated_with_ellipsis() {
+        let long = "x".repeat(100);
+        let preview = snippet_preview(&long);
+        assert_eq!(preview.chars().count(), 81); // 80 chars + ellipsis
+        assert!(preview.ends_with('…'));
+    }
+
+    #[test]
+    fn snippet_preview_multiline_keeps_first_line_and_appends_ellipsis() {
+        let multi = "first line\nsecond line\nthird";
+        assert_eq!(snippet_preview(multi), "first line…");
+    }
+
+    #[test]
+    fn snippet_preview_empty_input_safe() {
+        assert_eq!(snippet_preview(""), "");
+    }
+
+    #[test]
+    fn snippet_preview_unicode_first_line_truncates_by_chars_not_bytes() {
+        // Multi-byte chars (emoji + accents) should count by char,
+        // not byte — `chars().take(80)` enforces this. 80 emojis
+        // (4 bytes each) shouldn't push the truncation boundary
+        // incorrectly.
+        let unicode_long: String = std::iter::repeat('🎯').take(100).collect();
+        let preview = snippet_preview(&unicode_long);
+        assert_eq!(preview.chars().count(), 81); // 80 + ellipsis
+    }
+}


### PR DESCRIPTION
Phase 1A slice 2. Same shape as the web-search migration in #83: extract the hand-coded SearchResult-construction block from \`lib.rs::search\` into a \`ResultProvider\` impl. No external behavior change.

## What lands
- **\`search::providers::snippets::SnippetsProvider\`** — borrows \`&SnippetsManager\`, calls \`manager.search(query)\`, packages matches as SearchResults. Same score (8000), same id format, same "trigger — name" title format
- **\`snippet_preview\`** helper relocates from \`lib.rs\` to the provider module (it's only used here now). Picks up 5 unit tests that weren't exercised previously: short single-line, long single-line truncation, multi-line collapse, empty input, unicode-by-char-not-byte truncation
- **\`lib.rs::search\`** calls the provider; the inline \`if let Ok(snippets) = ... for snippet in snippets\` block is gone

## Migration progress
| Provider | Status |
|---|---|
| web_search | ✅ #83 |
| **snippets** | ✅ this PR |
| apps | next |
| windows | |
| browser_tabs | |
| system_command | |
| calculator | |
| notes (async) | needs trait-async decision |
| file_search (async) | needs trait-async decision |

The dispatcher in \`lib.rs::search\` is still not yet a registry loop — it'll convert once enough providers have migrated to make the loop meaningful.

## Test plan
- [x] \`cargo test --lib\` — 362 pass (5 new)
- [x] \`npm test --run\` — 103/103 pass (no frontend touched)
- [x] \`cargo check\` clean
- [ ] CI cross-platform compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)