### PR TITLE
refactor(search): migrate apps to ResultProvider (Phase 1A slice 3)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ use db::{AppEntry, Database};
 use indexers::{get_indexer, AppIndexer};
 use search::dispatch::{classify_prefix_route, Route, SubQuery};
 use search::provider::ResultProvider;
+use search::providers::apps::AppsProvider;
 use search::providers::snippets::SnippetsProvider;
 use search::providers::web_search::WebSearchProvider;
 use search::{ResultType, SearchAction, SearchEngine, SearchResult};
@@ -419,31 +420,20 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         .search(&query),
     );
 
-    // Add apps
+    // Phase 1A: apps via `ResultProvider`. The dispatcher gates the
+    // call on `!query.contains(' ') || items.is_empty()` (single-word
+    // query, OR fall back when nothing else matched) — that perf trim
+    // stays here because it short-circuits the entire app emission,
+    // not just per-app filtering.
     if !query.contains(' ') || items.is_empty() {
-        let now = chrono::Utc::now().timestamp();
-        let use_frequency_ranking = settings.search.use_frequency_ranking;
-        for app in apps.iter() {
-            let bonus = if use_frequency_ranking {
-                search::ranking::frecency_score(app.launch_count, app.last_launched, now)
-            } else {
-                0.0
-            };
-            items.push(SearchResult {
-                id: app.id.clone(),
-                name: app.name.clone(),
-                description: "Application".to_string(),
-                icon: app.icon_cache_path.clone(),
-                result_type: ResultType::Application,
-                score: 0,
-                frecency_score: bonus,
-                preview: None,
-                pinned: false,
-                action: SearchAction::LaunchApp {
-                    path: app.path.clone(),
-                },
-            });
-        }
+        items.extend(
+            AppsProvider {
+                apps: &apps,
+                use_frequency_ranking: settings.search.use_frequency_ranking,
+                now: chrono::Utc::now().timestamp(),
+            }
+            .search(&query),
+        );
     }
 
     // Gemini Improvement #6: Add open windows to search results.

--- a/src-tauri/src/search/providers/apps.rs
+++ b/src-tauri/src/search/providers/apps.rs
@@ -1,0 +1,172 @@
+//! Indexed-application provider.
+//!
+//! Emits one `SearchResult` per indexed app. Fuzzy matching against
+//! the query happens downstream in `SearchEngine::search` — the
+//! provider's job is to package every app with its frecency bonus
+//! and let the engine rank them.
+//!
+//! Why we don't filter here: the existing dispatcher relies on the
+//! engine's fuzzy scoring being consistent across all result kinds
+//! (apps, snippets, web searches, …). Doing a partial filter inside
+//! the provider would either bypass that ranking or duplicate it.
+//! The downstream cost is bounded — apps are typically ≤ a few
+//! hundred entries.
+//!
+//! The dispatcher gates calling this provider on
+//! `!query.contains(' ') || items.is_empty()` (single-word query or
+//! "fall back when nothing else matched"). That perf trim stays in
+//! the dispatcher; this provider doesn't peek at items count.
+
+use crate::db::AppEntry;
+use crate::search::provider::ResultProvider;
+use crate::search::ranking::frecency_score;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+pub struct AppsProvider<'a> {
+    pub apps: &'a [AppEntry],
+    /// When false, all apps emit `frecency_score: 0.0` and rank purely
+    /// by fuzzy match score. Mirrors the `settings.search
+    /// .use_frequency_ranking` switch.
+    pub use_frequency_ranking: bool,
+    /// Current Unix timestamp; passed in so the provider stays pure
+    /// (no clock reads inside the trait) and tests can pin time.
+    pub now: i64,
+}
+
+impl<'a> ResultProvider for AppsProvider<'a> {
+    fn name(&self) -> &'static str {
+        "apps"
+    }
+
+    fn search(&self, _query: &str) -> Vec<SearchResult> {
+        // The query is intentionally ignored here. Fuzzy ranking lives
+        // in `SearchEngine::search` downstream and handles all result
+        // kinds uniformly; if we filtered here we'd skip the engine's
+        // scoring and break the relative ordering between apps and
+        // other result kinds.
+        self.apps
+            .iter()
+            .map(|app| {
+                let bonus = if self.use_frequency_ranking {
+                    frecency_score(app.launch_count, app.last_launched, self.now)
+                } else {
+                    0.0
+                };
+                SearchResult {
+                    id: app.id.clone(),
+                    name: app.name.clone(),
+                    description: "Application".to_string(),
+                    icon: app.icon_cache_path.clone(),
+                    result_type: ResultType::Application,
+                    score: 0,
+                    frecency_score: bonus,
+                    preview: None,
+                    pinned: false,
+                    action: SearchAction::LaunchApp {
+                        path: app.path.clone(),
+                    },
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn app(id: &str, name: &str, launches: i32, last: Option<i64>) -> AppEntry {
+        AppEntry {
+            id: id.into(),
+            name: name.into(),
+            path: format!("/Applications/{name}.app"),
+            icon_cache_path: None,
+            launch_count: launches,
+            last_launched: last,
+            platform: "test".into(),
+            modified_at: 0,
+        }
+    }
+
+    #[test]
+    fn empty_apps_returns_empty() {
+        let p = AppsProvider {
+            apps: &[],
+            use_frequency_ranking: true,
+            now: 0,
+        };
+        assert!(p.search("anything").is_empty());
+    }
+
+    #[test]
+    fn maps_each_app_to_one_search_result() {
+        let apps = vec![
+            app("a:1", "Brave", 0, None),
+            app("a:2", "Chrome", 0, None),
+            app("a:3", "Firefox", 0, None),
+        ];
+        let p = AppsProvider {
+            apps: &apps,
+            use_frequency_ranking: false,
+            now: 0,
+        };
+        let results = p.search("");
+        assert_eq!(results.len(), 3);
+        assert_eq!(results[0].name, "Brave");
+        assert_eq!(results[2].name, "Firefox");
+    }
+
+    #[test]
+    fn frequency_off_zeroes_the_bonus() {
+        let apps = vec![app("a:1", "Brave", 999, Some(0))];
+        let p = AppsProvider {
+            apps: &apps,
+            use_frequency_ranking: false,
+            now: 1_700_000_000,
+        };
+        let r = &p.search("")[0];
+        assert_eq!(r.frecency_score, 0.0);
+    }
+
+    #[test]
+    fn frequency_on_emits_nonzero_bonus_for_used_apps() {
+        let apps = vec![
+            app("a:never", "Never used", 0, None),
+            app("a:hot", "Frequently used", 50, Some(1_699_990_000)),
+        ];
+        let p = AppsProvider {
+            apps: &apps,
+            use_frequency_ranking: true,
+            now: 1_700_000_000,
+        };
+        let results = p.search("");
+        // Unused app gets 0; hot app gets a positive score.
+        assert_eq!(results[0].frecency_score, 0.0);
+        assert!(results[1].frecency_score > 0.0);
+    }
+
+    #[test]
+    fn search_action_is_launch_app_with_path() {
+        let apps = vec![app("a:1", "Brave", 0, None)];
+        let p = AppsProvider {
+            apps: &apps,
+            use_frequency_ranking: false,
+            now: 0,
+        };
+        let r = &p.search("")[0];
+        assert!(matches!(
+            r.action,
+            SearchAction::LaunchApp { ref path } if path.contains("Brave")
+        ));
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let p = AppsProvider {
+            apps: &[],
+            use_frequency_ranking: false,
+            now: 0,
+        };
+        assert_eq!(p.name(), "apps");
+    }
+}

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -13,5 +13,6 @@
 //! 5. async providers (notes, file_search) — needs trait-async
 //!    decision
 
+pub mod apps;
 pub mod snippets;
 pub mod web_search;


### PR DESCRIPTION
Phase 1A slice 3. Same shape as the prior two migrations: extract the hand-coded SearchResult-construction block from `lib.rs::search` into a `ResultProvider` impl. No external behavior change.

## What lands
- `search::providers::apps::AppsProvider` — borrows the indexed apps slice, takes `use_frequency_ranking` flag and current Unix timestamp as fields. Query parameter intentionally ignored: fuzzy ranking lives in `SearchEngine::search`; filtering inside the provider would either bypass that ranking or duplicate it.
- The dispatcher gate `!query.contains(' ') || items.is_empty()` stays in `lib.rs::search` because it short-circuits the entire app emission, not per-app filtering.
- 6 unit tests covering empty input, full mapping, frecency off/on, action shape, and provider-name stability.

## Migration progress
| Provider | Status |
|---|---|
| `web_search` | ✅ #83 |
| `snippets` | ✅ #84 |
| **`apps`** | ✅ this PR |
| `windows` | next |
| `browser_tabs` | |
| `system_command` | |
| `calculator` | |
| `notes` (async) | |
| `file_search` (async) | |

## Test plan
- [x] `cargo test --lib` — 368 pass (6 new)
- [x] `cargo check` clean
- [ ] CI cross-platform compile