### PR TITLE
refactor(search): migrate windows + browser_tabs to ResultProvider (Phase 1A slice 4)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,8 +28,10 @@ use indexers::{get_indexer, AppIndexer};
 use search::dispatch::{classify_prefix_route, Route, SubQuery};
 use search::provider::ResultProvider;
 use search::providers::apps::AppsProvider;
+use search::providers::browser_tabs::BrowserTabsProvider;
 use search::providers::snippets::SnippetsProvider;
 use search::providers::web_search::WebSearchProvider;
+use search::providers::windows::WindowsProvider;
 use search::{ResultType, SearchAction, SearchEngine, SearchResult};
 use std::sync::{Arc, RwLock};
 use tauri::{Manager, State};
@@ -436,62 +438,24 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         );
     }
 
-    // Gemini Improvement #6: Add open windows to search results.
-    if let Ok(windows) = actions::windows::get_open_windows() {
-        for window in windows {
-            // For browser windows, also surface every tab as its own
-            // switcher row via UIA. The window-level row stays in the
-            // list — selecting it focuses the window without changing
-            // the active tab. Selecting a tab row activates that tab.
-            let is_browser = actions::browser_tabs::is_browser_process(&window.process_name);
-            if is_browser {
-                if let Ok(tabs) =
-                    actions::browser_tabs::get_browser_tabs(window.hwnd, &window.process_name)
-                {
-                    for tab in tabs {
-                        items.push(SearchResult {
-                            // Composite id: window HWND + tab index. Stable
-                            // for React keying within a single enum.
-                            id: format!("tab:{:x}:{}", tab.window_hwnd, tab.index),
-                            name: tab.name.clone(),
-                            description: format!("Tab in {}", tab.process_name),
-                            icon: Some("browser_tab".to_string()),
-                            result_type: ResultType::BrowserTab,
-                            // Rank tabs slightly above plain windows so
-                            // when both match, the more specific tab
-                            // surfaces first.
-                            score: 200,
-                            frecency_score: 0.0,
-                            preview: None,
-                            pinned: false,
-                            action: SearchAction::FocusBrowserTab {
-                                hwnd: tab.window_hwnd,
-                                index: tab.index,
-                            },
-                        });
-                    }
-                }
-            }
-
-            items.push(SearchResult {
-                // HWND is unique per window; using it as the id means
-                // multi-window apps (Brave with three browser windows,
-                // VS Code with two projects) get distinct switcher rows
-                // instead of collapsing into one.
-                id: format!("win:{:x}", window.hwnd),
-                name: window.title,
-                description: format!("Switch to {}", window.process_name),
-                icon: Some("window".to_string()),
-                result_type: ResultType::OpenWindow,
-                // Rank windows slightly higher than apps by giving them a base score.
-                score: 100,
-                frecency_score: 0.0,
-                preview: None,
-                pinned: false,
-                action: SearchAction::FocusWindow { hwnd: window.hwnd },
-            });
+    // Phase 1A: open windows + browser tabs via two `ResultProvider`
+    // impls that share a single `get_open_windows()` enumeration —
+    // the cross-platform FFI work runs once per query, not twice.
+    // Errors are silenced here (same policy as before): an empty
+    // window list yields zero results from both providers.
+    let open_windows = actions::windows::get_open_windows().unwrap_or_default();
+    items.extend(
+        BrowserTabsProvider {
+            windows: &open_windows,
         }
-    }
+        .search(&query),
+    );
+    items.extend(
+        WindowsProvider {
+            windows: &open_windows,
+        }
+        .search(&query),
+    );
 
     // Gemini Improvement #2: Add files with frecency bonus.
     if let Ok(files) = state.file_search.get_recent(50) {

--- a/src-tauri/src/search/providers/browser_tabs.rs
+++ b/src-tauri/src/search/providers/browser_tabs.rs
@@ -1,0 +1,108 @@
+//! Browser-tab provider.
+//!
+//! For each window in the supplied slice that belongs to a known
+//! browser process, queries `actions::browser_tabs::get_browser_tabs`
+//! and emits one `SearchResult` per tab. Tab rows score slightly
+//! above plain window rows so the more-specific "switch to *this*
+//! tab" surfaces ahead of "switch to the browser window" when both
+//! match.
+//!
+//! Lifetime: shares the same `&[WindowEntry]` slice the
+//! `WindowsProvider` consumes — the dispatcher enumerates windows
+//! once and passes the result to both providers.
+//!
+//! Unit tests for this provider are intentionally light because the
+//! tab-enumeration call is cross-platform FFI (UIA on Windows, AX on
+//! macOS, AT-SPI on Linux) and not easily mockable. Behavioral
+//! confidence comes from the live captures we ran during the
+//! original switcher work and the existing tab-enum tests inside
+//! `actions::browser_tabs`.
+
+use crate::actions::{browser_tabs, windows::WindowEntry};
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// Score tabs land on. Above the open-window score (100) so the
+/// tab-level row surfaces ahead of the window-level row when both
+/// match the query.
+const BROWSER_TAB_SCORE: i64 = 200;
+
+pub struct BrowserTabsProvider<'a> {
+    pub windows: &'a [WindowEntry],
+}
+
+impl<'a> ResultProvider for BrowserTabsProvider<'a> {
+    fn name(&self) -> &'static str {
+        "browser_tabs"
+    }
+
+    fn search(&self, _query: &str) -> Vec<SearchResult> {
+        let mut results = Vec::new();
+        for window in self.windows {
+            // Skip non-browser windows up front — the FFI call to
+            // get_browser_tabs is non-trivial (~50ms on a cold tree
+            // walk) and yields nothing useful for non-browsers.
+            if !browser_tabs::is_browser_process(&window.process_name) {
+                continue;
+            }
+            let tabs = match browser_tabs::get_browser_tabs(window.hwnd, &window.process_name) {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
+            for tab in tabs {
+                results.push(SearchResult {
+                    // Composite id: window HWND + tab index. Stable
+                    // for React keying within a single enumeration.
+                    id: format!("tab:{:x}:{}", tab.window_hwnd, tab.index),
+                    name: tab.name.clone(),
+                    description: format!("Tab in {}", tab.process_name),
+                    icon: Some("browser_tab".to_string()),
+                    result_type: ResultType::BrowserTab,
+                    score: BROWSER_TAB_SCORE,
+                    frecency_score: 0.0,
+                    preview: None,
+                    pinned: false,
+                    action: SearchAction::FocusBrowserTab {
+                        hwnd: tab.window_hwnd,
+                        index: tab.index,
+                    },
+                });
+            }
+        }
+        results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_windows_returns_empty() {
+        let p = BrowserTabsProvider { windows: &[] };
+        assert!(p.search("").is_empty());
+    }
+
+    #[test]
+    fn non_browser_processes_skipped_without_ffi_call() {
+        // The provider should short-circuit before reaching
+        // `get_browser_tabs` for non-browser processes. We can't
+        // observe the FFI call directly, but we can confirm an
+        // empty result for windows whose process_name doesn't
+        // match the browser allowlist.
+        let windows = vec![WindowEntry {
+            hwnd: 1,
+            pid: 0,
+            process_name: "definitely-not-a-browser-12345".into(),
+            title: "Not a browser".into(),
+        }];
+        let p = BrowserTabsProvider { windows: &windows };
+        assert!(p.search("").is_empty());
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let p = BrowserTabsProvider { windows: &[] };
+        assert_eq!(p.name(), "browser_tabs");
+    }
+}

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -14,5 +14,7 @@
 //!    decision
 
 pub mod apps;
+pub mod browser_tabs;
 pub mod snippets;
 pub mod web_search;
+pub mod windows;

--- a/src-tauri/src/search/providers/windows.rs
+++ b/src-tauri/src/search/providers/windows.rs
@@ -1,0 +1,122 @@
+//! Open-window provider.
+//!
+//! Emits one `SearchResult` per visible top-level window, scored
+//! slightly above plain apps so an open window outranks the
+//! corresponding "Launch" entry when both match the query (the user
+//! typically wants to switch, not re-launch).
+//!
+//! Lifetime: borrows a slice of already-enumerated windows. The
+//! dispatcher in `lib.rs::search` calls
+//! `actions::windows::get_open_windows()` once per query and passes
+//! the slice to BOTH this provider and `BrowserTabsProvider`, so the
+//! cross-platform FFI work doesn't run twice.
+
+use crate::actions::windows::WindowEntry;
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// Score open windows land on. Above the apps floor (0) so when an
+/// app is already open we surface "switch to it" rather than
+/// "launch a second copy".
+const OPEN_WINDOW_SCORE: i64 = 100;
+
+pub struct WindowsProvider<'a> {
+    pub windows: &'a [WindowEntry],
+}
+
+impl<'a> ResultProvider for WindowsProvider<'a> {
+    fn name(&self) -> &'static str {
+        "windows"
+    }
+
+    fn search(&self, _query: &str) -> Vec<SearchResult> {
+        // Query intentionally ignored — fuzzy ranking lives in
+        // `SearchEngine::search` downstream and handles all kinds
+        // uniformly.
+        self.windows
+            .iter()
+            .map(|window| SearchResult {
+                // HWND is unique per window; using it as the id means
+                // multi-window apps (browser with three windows,
+                // editor with two projects) get distinct switcher rows
+                // instead of collapsing into one.
+                id: format!("win:{:x}", window.hwnd),
+                name: window.title.clone(),
+                description: format!("Switch to {}", window.process_name),
+                icon: Some("window".to_string()),
+                result_type: ResultType::OpenWindow,
+                score: OPEN_WINDOW_SCORE,
+                frecency_score: 0.0,
+                preview: None,
+                pinned: false,
+                action: SearchAction::FocusWindow { hwnd: window.hwnd },
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn win(hwnd: i64, title: &str, process: &str) -> WindowEntry {
+        WindowEntry {
+            hwnd,
+            pid: 0,
+            process_name: process.into(),
+            title: title.into(),
+        }
+    }
+
+    #[test]
+    fn empty_windows_returns_empty() {
+        let p = WindowsProvider { windows: &[] };
+        assert!(p.search("").is_empty());
+    }
+
+    #[test]
+    fn each_window_becomes_one_result_with_focus_window_action() {
+        let windows = vec![
+            win(0x100, "Project A — VS Code", "code"),
+            win(0x200, "Inbox — Mail", "mail"),
+        ];
+        let p = WindowsProvider { windows: &windows };
+        let results = p.search("");
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "Project A — VS Code");
+        assert!(matches!(
+            results[0].action,
+            SearchAction::FocusWindow { hwnd } if hwnd == 0x100
+        ));
+        assert_eq!(results[1].id, "win:200");
+    }
+
+    #[test]
+    fn ids_are_distinct_for_different_hwnds_with_same_title() {
+        // Multi-window apps (browser with two windows of the same
+        // page title) need distinct ids or the listbox de-dupes them
+        // against each other.
+        let windows = vec![
+            win(0x100, "GitHub", "browser"),
+            win(0x101, "GitHub", "browser"),
+        ];
+        let p = WindowsProvider { windows: &windows };
+        let results = p.search("");
+        assert_eq!(results[0].id, "win:100");
+        assert_eq!(results[1].id, "win:101");
+        assert_ne!(results[0].id, results[1].id);
+    }
+
+    #[test]
+    fn description_uses_process_name() {
+        let windows = vec![win(0x1, "Whatever", "Custom Process")];
+        let p = WindowsProvider { windows: &windows };
+        assert_eq!(p.search("")[0].description, "Switch to Custom Process");
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let p = WindowsProvider { windows: &[] };
+        assert_eq!(p.name(), "windows");
+    }
+}


### PR DESCRIPTION
Phase 1A slice 4. Two providers in one PR because they share a single `get_open_windows()` enumeration — the cross-platform FFI work runs once per query, not twice.

## What lands
- `search::providers::windows::WindowsProvider` — borrows the enumerated windows slice, emits one `SearchResult` per visible top-level window with score 100. 5 unit tests.
- `search::providers::browser_tabs::BrowserTabsProvider` — shares the same slice, filters to known browser processes, calls `get_browser_tabs` per browser window, emits tab rows with score 200. 3 unit tests (FFI path covered by existing integration tests).
- Dispatcher in `lib.rs::search` now calls `get_open_windows()` once and threads the result into both providers via shared borrow. Tab results before window results (preserves prior iteration order; downstream sort by score is the same either way).

## Migration progress
| Provider | Status |
|---|---|
| `web_search` | ✅ |
| `snippets` | ✅ |
| `apps` | ✅ |
| **`windows` + `browser_tabs`** | ✅ this PR |
| `system_command`, `calculator` | next |
| `notes`, `file_search` | needs trait-async |

## Test plan
- [x] `cargo test --lib` — 376 pass (8 new)
- [x] `cargo check` clean
- [ ] CI cross-platform compile