### PR TITLE
refactor(search): migrate calculator + system_commands to ResultProvider (Phase 1A slice 5)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,7 +29,9 @@ use search::dispatch::{classify_prefix_route, Route, SubQuery};
 use search::provider::ResultProvider;
 use search::providers::apps::AppsProvider;
 use search::providers::browser_tabs::BrowserTabsProvider;
+use search::providers::calculator::CalculatorProvider;
 use search::providers::snippets::SnippetsProvider;
+use search::providers::system_commands::SystemCommandsProvider;
 use search::providers::web_search::WebSearchProvider;
 use search::providers::windows::WindowsProvider;
 use search::{ResultType, SearchAction, SearchEngine, SearchResult};
@@ -213,69 +215,10 @@ async fn files_route_results(state: &State<'_, AppState>, sub: SubQuery) -> Vec<
     out
 }
 
-/// Wrap a successful calculation into the single `SearchResult` the UI
-/// renders. WAT-203 short-circuits the pipeline on detection, so this is
-/// the only result returned for a calculator query.
-fn calculation_result(calc: calculator::Calculation) -> SearchResult {
-    // The id is derived from the expression so identical repeats reuse
-    // the same result row (stable for React keying and de-dup).
-    let id = format!("calc:{}", calc.expression);
-    // Copy only the plain result value — not the "rates from ..." suffix
-    // on currency — so pasting somewhere else gives a clean number.
-    let copy_value = calc
-        .result
-        .split_once(" (")
-        .map(|(head, _)| head.to_string())
-        .unwrap_or_else(|| calc.result.clone());
-    SearchResult {
-        id,
-        name: format!("{} = {}", calc.expression, calc.result),
-        description: "Press Enter to copy".to_string(),
-        icon: Some("calculator".to_string()),
-        result_type: ResultType::Calculation,
-        score: 100000, // Above everything else; we've already short-circuited.
-        frecency_score: 0.0,
-        preview: None,
-        pinned: false,
-        action: SearchAction::CopyClipboard { content: copy_value },
-    }
-}
-
-/// WAT-306: dispatch for the `>` prefix. `>` alone returns every command
-/// in its registered order; `>foo` (or `> foo`) filters aliases by
-/// case-insensitive substring match. Runs exclusively — no apps, web
-/// searches, or other result types mix in.
-fn system_commands_route_results(sub: SubQuery) -> Vec<SearchResult> {
-    let filter = match sub {
-        SubQuery::Listing => None,
-        SubQuery::Search(q) if q.is_empty() => None,
-        SubQuery::Search(q) => Some(q.to_lowercase()),
-    };
-
-    get_system_commands()
-        .into_iter()
-        .filter(|cmd| match &filter {
-            None => true,
-            Some(needle) => cmd
-                .aliases
-                .iter()
-                .any(|alias| alias.to_lowercase().contains(needle))
-                || cmd.name.to_lowercase().contains(needle.as_str()),
-        })
-        .map(|cmd| SearchResult {
-            id: cmd.id.clone(),
-            name: cmd.name.clone(),
-            description: cmd.description.clone(),
-            icon: Some("system".to_string()),
-            result_type: ResultType::SystemCommand,
-            score: 5000,
-            frecency_score: 0.0,
-            preview: None,
-            pinned: false,
-            action: SearchAction::RunCommand { command: cmd.id },
-        })
-        .collect()
-}
+// Phase 1A: `calculation_result` and `system_commands_route_results`
+// have moved to `search::providers::calculator` and
+// `search::providers::system_commands` respectively. The dispatcher
+// in `search()` instantiates each provider per call.
 
 /// WAT-304: build the empty-query default view — up to 5 recently-launched
 /// apps + up to 5 recently-opened files, interleaved by timestamp so the
@@ -382,8 +325,13 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
     // query looks like math or a unit/currency conversion. The detector
     // is conservative — ordinary search queries ("apple", "chrome",
     // "iphone 15") fall through to the normal pipeline.
-    if let Some(calc) = calculator::detect(&query) {
-        return Ok(vec![calculation_result(calc)]);
+    // WAT-203 short-circuit: if the query parses as math / unit /
+    // currency, skip the rest of the pipeline and return only the
+    // calculator's row. The provider returns an empty Vec for
+    // non-math input, so checking for non-empty is the discriminator.
+    let calc_results = CalculatorProvider.search(&query);
+    if !calc_results.is_empty() {
+        return Ok(calc_results);
     }
 
     match classify_prefix_route(&query) {
@@ -391,7 +339,7 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         Route::Notes(sub) => return Ok(notes_route_results(&state, sub).await),
         Route::Files(sub) => return Ok(files_route_results(&state, sub).await),
         Route::Clipboard(sub) => return Ok(clipboard_route_results(&state, sub)),
-        Route::SystemCommands(sub) => return Ok(system_commands_route_results(sub)),
+        Route::SystemCommands(sub) => return Ok(SystemCommandsProvider { sub }.search(&query)),
         Route::Passthrough => {}
     }
 

--- a/src-tauri/src/search/providers/calculator.rs
+++ b/src-tauri/src/search/providers/calculator.rs
@@ -1,0 +1,118 @@
+//! Inline-calculator provider.
+//!
+//! Detects arithmetic, unit conversions, and currency conversions in
+//! the query and emits a single result row showing the answer. The
+//! dispatcher checks this provider FIRST and short-circuits the rest
+//! of the pipeline if it returns a non-empty result — a query that
+//! looks like math (`2+2`, `10mi to km`, `5 usd to eur`) should not
+//! also surface app launches or web searches.
+//!
+//! The detector in `calculator::detect` is conservative: ordinary
+//! search queries ("apple", "iphone 15") fall through to an empty
+//! result here and the regular pipeline runs.
+
+use crate::calculator;
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// Score for calculator results. Above every other score (10000 for
+/// recents, 8000 for snippets, 200 for tabs, 100 for windows, 0 for
+/// apps) — but the dispatcher's short-circuit means this is academic
+/// since calculator runs exclusively when it matches.
+const CALCULATOR_SCORE: i64 = 100_000;
+
+pub struct CalculatorProvider;
+
+impl ResultProvider for CalculatorProvider {
+    fn name(&self) -> &'static str {
+        "calculator"
+    }
+
+    fn search(&self, query: &str) -> Vec<SearchResult> {
+        let Some(calc) = calculator::detect(query) else {
+            return Vec::new();
+        };
+        vec![build_result(calc)]
+    }
+}
+
+fn build_result(calc: calculator::Calculation) -> SearchResult {
+    // The id is derived from the expression so identical repeats reuse
+    // the same result row (stable for React keying and de-dup).
+    let id = format!("calc:{}", calc.expression);
+    // Copy only the plain result value — not the "rates from ..."
+    // suffix on currency conversions — so pasting somewhere else
+    // gives a clean number.
+    let copy_value = calc
+        .result
+        .split_once(" (")
+        .map(|(head, _)| head.to_string())
+        .unwrap_or_else(|| calc.result.clone());
+    SearchResult {
+        id,
+        name: format!("{} = {}", calc.expression, calc.result),
+        description: "Press Enter to copy".to_string(),
+        icon: Some("calculator".to_string()),
+        result_type: ResultType::Calculation,
+        score: CALCULATOR_SCORE,
+        frecency_score: 0.0,
+        preview: None,
+        pinned: false,
+        action: SearchAction::CopyClipboard {
+            content: copy_value,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_math_query_returns_empty() {
+        let p = CalculatorProvider;
+        assert!(p.search("hello world").is_empty());
+        assert!(p.search("apple").is_empty());
+        assert!(p.search("").is_empty());
+    }
+
+    #[test]
+    fn arithmetic_returns_one_result() {
+        let p = CalculatorProvider;
+        let results = p.search("2 + 2");
+        assert_eq!(results.len(), 1);
+        let r = &results[0];
+        assert!(r.name.contains("4"));
+        assert_eq!(r.id, "calc:2 + 2");
+    }
+
+    #[test]
+    fn copy_action_strips_currency_rate_suffix() {
+        // The expected display includes "5 USD = 4.50 EUR (rates
+        // from ...)" — the copyable value should be "4.50 EUR" only.
+        // We can't easily mock the currency rate fetcher here, so
+        // we test the suffix-stripping helper indirectly via a
+        // synthetic Calculation — but the underlying logic is
+        // exercised by the existing calculator integration tests.
+        // Just smoke-test the action shape on a deterministic
+        // arithmetic case.
+        let p = CalculatorProvider;
+        let results = p.search("10 * 3");
+        assert_eq!(results.len(), 1);
+        match &results[0].action {
+            SearchAction::CopyClipboard { content } => {
+                // Pure arithmetic has no parenthetical suffix to
+                // strip; copy_value equals the result string.
+                assert!(content.contains("30"));
+                assert!(!content.contains('('));
+            }
+            _ => panic!("expected CopyClipboard action"),
+        }
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let p = CalculatorProvider;
+        assert_eq!(p.name(), "calculator");
+    }
+}

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -15,6 +15,8 @@
 
 pub mod apps;
 pub mod browser_tabs;
+pub mod calculator;
 pub mod snippets;
+pub mod system_commands;
 pub mod web_search;
 pub mod windows;

--- a/src-tauri/src/search/providers/system_commands.rs
+++ b/src-tauri/src/search/providers/system_commands.rs
@@ -1,0 +1,139 @@
+//! System-command provider for the `>` route.
+//!
+//! Surfaces commands like `lock`, `sleep`, `restart`, `split-left`,
+//! `maximize`, etc. when the user types `>` (alone for full listing)
+//! or `>foo` (substring filter on aliases or name).
+//!
+//! Lifetime: takes a `SubQuery` directly via constructor — the
+//! dispatcher's route classifier has already split the prefix from
+//! the rest of the query, so re-parsing inside the provider would be
+//! redundant.
+//!
+//! Runs *exclusively* on the `>` route — the dispatcher does NOT mix
+//! its results with apps / web / snippets. The query parameter to
+//! `ResultProvider::search` is intentionally unused; the filter
+//! comes from `self.sub`.
+
+use crate::actions::system::get_system_commands;
+use crate::search::dispatch::SubQuery;
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// Score for system-command rows. Above apps, web, and snippets so
+/// commands surface above ambient matches when the user explicitly
+/// invoked the `>` route.
+const SYSTEM_COMMAND_SCORE: i64 = 5_000;
+
+pub struct SystemCommandsProvider {
+    /// Already-parsed sub-query from the route classifier. `Listing`
+    /// returns every registered command; `Search(q)` filters by
+    /// case-insensitive substring against aliases or display name.
+    pub sub: SubQuery,
+}
+
+impl ResultProvider for SystemCommandsProvider {
+    fn name(&self) -> &'static str {
+        "system_commands"
+    }
+
+    fn search(&self, _query: &str) -> Vec<SearchResult> {
+        let filter = match &self.sub {
+            SubQuery::Listing => None,
+            SubQuery::Search(q) if q.is_empty() => None,
+            SubQuery::Search(q) => Some(q.to_lowercase()),
+        };
+
+        get_system_commands()
+            .into_iter()
+            .filter(|cmd| match &filter {
+                None => true,
+                Some(needle) => cmd
+                    .aliases
+                    .iter()
+                    .any(|alias| alias.to_lowercase().contains(needle))
+                    || cmd.name.to_lowercase().contains(needle.as_str()),
+            })
+            .map(|cmd| SearchResult {
+                id: cmd.id.clone(),
+                name: cmd.name.clone(),
+                description: cmd.description.clone(),
+                icon: Some("system".to_string()),
+                result_type: ResultType::SystemCommand,
+                score: SYSTEM_COMMAND_SCORE,
+                frecency_score: 0.0,
+                preview: None,
+                pinned: false,
+                action: SearchAction::RunCommand { command: cmd.id },
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn listing_returns_every_registered_command() {
+        let p = SystemCommandsProvider {
+            sub: SubQuery::Listing,
+        };
+        let results = p.search("");
+        // Every registered command surfaces, no filter applied.
+        // The exact count varies as commands are added/removed; we
+        // only assert non-empty + every result has the expected
+        // shape.
+        assert!(!results.is_empty());
+        for r in &results {
+            assert_eq!(r.score, SYSTEM_COMMAND_SCORE);
+            assert!(matches!(r.result_type, ResultType::SystemCommand));
+            assert!(matches!(r.action, SearchAction::RunCommand { .. }));
+        }
+    }
+
+    #[test]
+    fn empty_search_treated_as_listing() {
+        let p_listing = SystemCommandsProvider {
+            sub: SubQuery::Listing,
+        };
+        let p_empty = SystemCommandsProvider {
+            sub: SubQuery::Search(String::new()),
+        };
+        assert_eq!(p_listing.search("").len(), p_empty.search("").len());
+    }
+
+    #[test]
+    fn substring_filter_matches_alias_case_insensitively() {
+        // "lock" should match the lock command's alias / name no
+        // matter the case the user types. Test against a token
+        // that's almost certainly in the registered commands.
+        let p_lower = SystemCommandsProvider {
+            sub: SubQuery::Search("lock".into()),
+        };
+        let p_upper = SystemCommandsProvider {
+            sub: SubQuery::Search("LOCK".into()),
+        };
+        let lower_results = p_lower.search("");
+        let upper_results = p_upper.search("");
+        // Same matches regardless of case.
+        assert_eq!(lower_results.len(), upper_results.len());
+        // Lock command is in the registered set.
+        assert!(!lower_results.is_empty(), "expected at least one lock-related command");
+    }
+
+    #[test]
+    fn nonexistent_token_returns_empty() {
+        let p = SystemCommandsProvider {
+            sub: SubQuery::Search("zzzz-not-a-command-token".into()),
+        };
+        assert!(p.search("").is_empty());
+    }
+
+    #[test]
+    fn provider_name_is_stable() {
+        let p = SystemCommandsProvider {
+            sub: SubQuery::Listing,
+        };
+        assert_eq!(p.name(), "system_commands");
+    }
+}


### PR DESCRIPTION
Phase 1A slice 5. Two providers in one PR — they pair naturally because both bypass the main pipeline: calculator short-circuits the dispatcher; system_commands runs exclusively on the `>` route.

## What lands
- `search::providers::calculator::CalculatorProvider` — wraps `calculator::detect` + SearchResult construction. Dispatcher calls it FIRST and returns results exclusively if non-empty (WAT-203 short-circuit preserved).
- `search::providers::system_commands::SystemCommandsProvider` — takes a `SubQuery` via constructor field. Filter logic + score (5000) + action shape unchanged. Runs only on the `>` route.
- `calculation_result` and `system_commands_route_results` free functions removed from `lib.rs`; their logic lives in the providers now.
- 9 new unit tests.

## Migration progress
| Provider | Status |
|---|---|
| web_search, snippets, apps | ✅ |
| windows, browser_tabs | ✅ |
| **calculator, system_commands** | ✅ this PR |
| notes (async) | next — needs trait-async decision |
| file_search (async) | next |

## Test plan
- [x] `cargo test --lib` — 385 pass (9 new)
- [x] `cargo check` clean
- [ ] CI cross-platform compile