### PR TITLE
refactor(search): async ResultProvider trait + notes/file_search migration (Phase 1A complete)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ dirs = "5.0"
 meval = "0.2"
 regex = "1"
 tokio = { version = "1", features = ["full"] }
+async-trait = "0.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 # UI Automation for browser tab enumeration. Only needed on Windows;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ use search::provider::ResultProvider;
 use search::providers::apps::AppsProvider;
 use search::providers::browser_tabs::BrowserTabsProvider;
 use search::providers::calculator::CalculatorProvider;
+use search::providers::file_search::FileSearchProvider;
+use search::providers::notes::NotesProvider;
 use search::providers::snippets::SnippetsProvider;
 use search::providers::system_commands::SystemCommandsProvider;
 use search::providers::web_search::WebSearchProvider;
@@ -102,123 +104,10 @@ fn reindex_apps(state: State<AppState>) -> usize {
     count
 }
 
-/// Gemini Improvement #4: clean plain-text snippet of a note's content.
-/// Strips markdown headers and collapses newlines to provide a dense
-/// preview for the search results row.
-fn note_preview(content: &str) -> String {
-    let clean = content
-        .lines()
-        .filter(|line| !line.trim().starts_with('#'))
-        .collect::<Vec<_>>()
-        .join(" ");
-    let clipped: String = clean.chars().take(100).collect();
-    if clean.chars().count() > 100 {
-        format!("{clipped}…")
-    } else {
-        clipped
-    }
-}
-
-async fn notes_route_results(state: &State<'_, AppState>, sub: SubQuery) -> Vec<SearchResult> {
-    let notes_res = match sub {
-        SubQuery::Listing => state.notes.get_recent(8).await,
-        SubQuery::Search(ref q) if q.is_empty() => state.notes.get_recent(8).await,
-        SubQuery::Search(q) => state.notes.search(&q).await,
-    };
-    let mut out: Vec<SearchResult> = notes_res
-        .map(|notes| {
-            notes
-                .into_iter()
-                .take(8)
-                .map(|note| SearchResult {
-                    id: note.id.clone(),
-                    name: note.title,
-                    description: format!("Note · {}", note.tags.join(", ")),
-                    icon: Some("note".to_string()),
-                    result_type: ResultType::Note,
-                    score: 10000,
-                    frecency_score: 0.0,
-                    preview: Some(note_preview(&note.content)),
-                    pinned: false,
-                    action: SearchAction::OpenNote { note_id: note.id },
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Always surface a "Create new note" entry in the notes route.
-    // This is the replacement for the bare-`n` keyboard shortcut that
-    // used to open the editor — without it, a user with zero notes
-    // who types `n` sees an empty list and can't tell that the route
-    // even fired.
-    out.push(SearchResult {
-        id: "note:__create__".to_string(),
-        name: "Create new note".to_string(),
-        description: "Open the editor with an empty note".to_string(),
-        icon: Some("note_new".to_string()),
-        result_type: ResultType::Note,
-        // Lower than recent notes (10000) so it sorts to the bottom
-        // when notes exist, but is the only result when they don't.
-        score: 1,
-        frecency_score: 0.0,
-        preview: None,
-        pinned: false,
-        action: SearchAction::CreateNewNote,
-    });
-    out
-}
-
-async fn files_route_results(state: &State<'_, AppState>, sub: SubQuery) -> Vec<SearchResult> {
-    let files = match sub {
-        SubQuery::Listing => state.file_search.get_recent(8),
-        SubQuery::Search(ref q) if q.is_empty() => state.file_search.get_recent(8),
-        SubQuery::Search(q) => state.file_search.search(&q, 8),
-    };
-    let mut out: Vec<SearchResult> = files
-        .map(|files| {
-            files
-                .into_iter()
-                .map(|file| SearchResult {
-                    id: file.id.clone(),
-                    name: file.name,
-                    description: file.path.clone(),
-                    icon: Some("file".to_string()),
-                    result_type: ResultType::File,
-                    score: 10000,
-                    frecency_score: 0.0,
-                    preview: None,
-                    pinned: false,
-                    action: SearchAction::OpenFile { path: file.path },
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    // Always surface a "Re-index files now" affordance — same pattern
-    // as the notes route's "Create new note". A user with an empty
-    // file index types `f` and otherwise sees nothing; this entry
-    // makes the empty-state visible and gives them a one-click path
-    // to populate the index from whatever paths are configured in
-    // Settings.
-    out.push(SearchResult {
-        id: "file:__reindex__".to_string(),
-        name: "Re-index files now".to_string(),
-        description: "Re-scan the configured indexed paths".to_string(),
-        icon: Some("file_reindex".to_string()),
-        result_type: ResultType::File,
-        score: 1, // sorts to the bottom when real files exist
-        frecency_score: 0.0,
-        preview: None,
-        pinned: false,
-        action: SearchAction::ReindexFiles,
-    });
-    out
-}
-
-// Phase 1A: `calculation_result` and `system_commands_route_results`
-// have moved to `search::providers::calculator` and
-// `search::providers::system_commands` respectively. The dispatcher
-// in `search()` instantiates each provider per call.
+// Phase 1A: notes / files / calculator / system_commands route
+// logic moved to providers in `search::providers::*`. The dispatcher
+// in `search()` instantiates each provider per call. The standalone
+// route-handler free functions that used to live here are gone.
 
 /// WAT-304: build the empty-query default view — up to 5 recently-launched
 /// apps + up to 5 recently-opened files, interleaved by timestamp so the
@@ -329,22 +218,52 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
     // currency, skip the rest of the pipeline and return only the
     // calculator's row. The provider returns an empty Vec for
     // non-math input, so checking for non-empty is the discriminator.
-    let calc_results = CalculatorProvider.search(&query);
+    let calc_results = CalculatorProvider.search(&query).await;
     if !calc_results.is_empty() {
         return Ok(calc_results);
     }
 
     match classify_prefix_route(&query) {
         Route::Empty => return Ok(recents_results(&state)),
-        Route::Notes(sub) => return Ok(notes_route_results(&state, sub).await),
-        Route::Files(sub) => return Ok(files_route_results(&state, sub).await),
+        Route::Notes(sub) => {
+            return Ok(NotesProvider {
+                manager: &state.notes,
+                sub,
+            }
+            .search(&query)
+            .await)
+        }
+        Route::Files(sub) => {
+            return Ok(FileSearchProvider {
+                manager: &state.file_search,
+                sub,
+            }
+            .search(&query)
+            .await)
+        }
         Route::Clipboard(sub) => return Ok(clipboard_route_results(&state, sub)),
-        Route::SystemCommands(sub) => return Ok(SystemCommandsProvider { sub }.search(&query)),
+        Route::SystemCommands(sub) => {
+            return Ok(SystemCommandsProvider { sub }.search(&query).await)
+        }
         Route::Passthrough => {}
     }
 
-    let settings = state.settings.read().unwrap();
-    let apps = state.indexed_apps.read().unwrap();
+    // Snapshot the lock-guarded state up front. Holding RwLockReadGuards
+    // across .await points fails the Send bound the async `search`
+    // command requires, so we clone what providers will need and drop
+    // the guards immediately. Settings.web_searches and indexed_apps
+    // are bounded in size (O(tens) and O(hundreds) respectively), so
+    // the clones are cheap; the alternative is a wider switch to
+    // `tokio::sync::RwLock` which we don't need yet.
+    let (web_searches, use_frequency_ranking, max_results) = {
+        let s = state.settings.read().unwrap();
+        (
+            s.web_searches.clone(),
+            s.search.use_frequency_ranking,
+            s.search.max_results,
+        )
+    };
+    let apps: Vec<AppEntry> = state.indexed_apps.read().unwrap().clone();
 
     let mut items: Vec<SearchResult> = Vec::new();
 
@@ -354,9 +273,10 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
     // dispatcher no longer hand-rolls the SearchResult struct.
     items.extend(
         WebSearchProvider {
-            configs: &settings.web_searches,
+            configs: &web_searches,
         }
-        .search(&query),
+        .search(&query)
+        .await,
     );
 
     // Phase 1A: snippets via `ResultProvider`. WAT-301 — runs as a
@@ -367,7 +287,8 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         SnippetsProvider {
             manager: &state.snippets,
         }
-        .search(&query),
+        .search(&query)
+        .await,
     );
 
     // Phase 1A: apps via `ResultProvider`. The dispatcher gates the
@@ -379,10 +300,11 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         items.extend(
             AppsProvider {
                 apps: &apps,
-                use_frequency_ranking: settings.search.use_frequency_ranking,
+                use_frequency_ranking,
                 now: chrono::Utc::now().timestamp(),
             }
-            .search(&query),
+            .search(&query)
+            .await,
         );
     }
 
@@ -396,13 +318,15 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         BrowserTabsProvider {
             windows: &open_windows,
         }
-        .search(&query),
+        .search(&query)
+        .await,
     );
     items.extend(
         WindowsProvider {
             windows: &open_windows,
         }
-        .search(&query),
+        .search(&query)
+        .await,
     );
 
     // Gemini Improvement #2: Add files with frecency bonus.
@@ -425,7 +349,7 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
 
     // Search and limit results
     let mut results = state.search_engine.search(&query, items);
-    results.truncate(settings.search.max_results);
+    results.truncate(max_results);
     Ok(results)
 }
 

--- a/src-tauri/src/search/provider.rs
+++ b/src-tauri/src/search/provider.rs
@@ -28,8 +28,11 @@ use crate::search::SearchResult;
 /// - Be cheap to construct — they are built per call.
 /// - Not panic on empty / malformed queries; return an empty Vec.
 ///
-/// Sync only for v1. Async providers stay hand-coded in the
-/// dispatcher pending a follow-up trait split.
+/// Async-by-default via `async_trait`. Most providers are pure
+/// in-memory transforms and just write `async fn search` returning
+/// immediately; the async kinds (notes, file_search) `.await`
+/// their backing store. One trait, one dispatcher loop.
+#[async_trait::async_trait]
 pub trait ResultProvider {
     /// Stable identifier used in logs / diagnostics. Should be a
     /// short snake_case slug ("web_search", "system_command",
@@ -38,7 +41,7 @@ pub trait ResultProvider {
 
     /// Run the provider against the query, returning its results.
     /// Caller appends these to a combined `Vec<SearchResult>`.
-    fn search(&self, query: &str) -> Vec<SearchResult>;
+    async fn search(&self, query: &str) -> Vec<SearchResult>;
 }
 
 #[cfg(test)]
@@ -51,11 +54,12 @@ mod tests {
     /// can hold and call providers through a trait object.
     struct StubProvider;
 
+    #[async_trait::async_trait]
     impl ResultProvider for StubProvider {
         fn name(&self) -> &'static str {
             "stub"
         }
-        fn search(&self, query: &str) -> Vec<SearchResult> {
+        async fn search(&self, query: &str) -> Vec<SearchResult> {
             if query == "match" {
                 vec![SearchResult {
                     id: "stub:1".into(),
@@ -84,29 +88,28 @@ mod tests {
         assert_eq!(p.name(), p.name());
     }
 
-    #[test]
-    fn empty_query_returns_empty_vec_without_panic() {
+    #[tokio::test]
+    async fn empty_query_returns_empty_vec_without_panic() {
         let p = StubProvider;
-        assert!(p.search("").is_empty());
+        assert!(p.search("").await.is_empty());
     }
 
-    #[test]
-    fn match_returns_results() {
+    #[tokio::test]
+    async fn match_returns_results() {
         let p = StubProvider;
-        let results = p.search("match");
+        let results = p.search("match").await;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "stub:1");
     }
 
-    #[test]
-    fn provider_works_through_dyn_dispatch() {
-        // The dispatcher will hold providers as
-        // `Box<dyn ResultProvider>`; verify trait-object dispatch
-        // works.
+    #[tokio::test]
+    async fn provider_works_through_dyn_dispatch() {
+        // The dispatcher holds providers as `Box<dyn ResultProvider>`;
+        // verify trait-object dispatch works for async fns too.
         let providers: Vec<Box<dyn ResultProvider>> = vec![Box::new(StubProvider)];
         let mut combined = Vec::new();
         for p in &providers {
-            combined.extend(p.search("match"));
+            combined.extend(p.search("match").await);
         }
         assert_eq!(combined.len(), 1);
     }

--- a/src-tauri/src/search/providers/apps.rs
+++ b/src-tauri/src/search/providers/apps.rs
@@ -33,12 +33,13 @@ pub struct AppsProvider<'a> {
     pub now: i64,
 }
 
+#[async_trait::async_trait]
 impl<'a> ResultProvider for AppsProvider<'a> {
     fn name(&self) -> &'static str {
         "apps"
     }
 
-    fn search(&self, _query: &str) -> Vec<SearchResult> {
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
         // The query is intentionally ignored here. Fuzzy ranking lives
         // in `SearchEngine::search` downstream and handles all result
         // kinds uniformly; if we filtered here we'd skip the engine's
@@ -88,18 +89,18 @@ mod tests {
         }
     }
 
-    #[test]
-    fn empty_apps_returns_empty() {
+    #[tokio::test]
+    async fn empty_apps_returns_empty() {
         let p = AppsProvider {
             apps: &[],
             use_frequency_ranking: true,
             now: 0,
         };
-        assert!(p.search("anything").is_empty());
+        assert!(p.search("anything").await.is_empty());
     }
 
-    #[test]
-    fn maps_each_app_to_one_search_result() {
+    #[tokio::test]
+    async fn maps_each_app_to_one_search_result() {
         let apps = vec![
             app("a:1", "Brave", 0, None),
             app("a:2", "Chrome", 0, None),
@@ -110,26 +111,26 @@ mod tests {
             use_frequency_ranking: false,
             now: 0,
         };
-        let results = p.search("");
+        let results = p.search("").await;
         assert_eq!(results.len(), 3);
         assert_eq!(results[0].name, "Brave");
         assert_eq!(results[2].name, "Firefox");
     }
 
-    #[test]
-    fn frequency_off_zeroes_the_bonus() {
+    #[tokio::test]
+    async fn frequency_off_zeroes_the_bonus() {
         let apps = vec![app("a:1", "Brave", 999, Some(0))];
         let p = AppsProvider {
             apps: &apps,
             use_frequency_ranking: false,
             now: 1_700_000_000,
         };
-        let r = &p.search("")[0];
-        assert_eq!(r.frecency_score, 0.0);
+        let results = p.search("").await;
+        assert_eq!(results[0].frecency_score, 0.0);
     }
 
-    #[test]
-    fn frequency_on_emits_nonzero_bonus_for_used_apps() {
+    #[tokio::test]
+    async fn frequency_on_emits_nonzero_bonus_for_used_apps() {
         let apps = vec![
             app("a:never", "Never used", 0, None),
             app("a:hot", "Frequently used", 50, Some(1_699_990_000)),
@@ -139,23 +140,23 @@ mod tests {
             use_frequency_ranking: true,
             now: 1_700_000_000,
         };
-        let results = p.search("");
+        let results = p.search("").await;
         // Unused app gets 0; hot app gets a positive score.
         assert_eq!(results[0].frecency_score, 0.0);
         assert!(results[1].frecency_score > 0.0);
     }
 
-    #[test]
-    fn search_action_is_launch_app_with_path() {
+    #[tokio::test]
+    async fn search_action_is_launch_app_with_path() {
         let apps = vec![app("a:1", "Brave", 0, None)];
         let p = AppsProvider {
             apps: &apps,
             use_frequency_ranking: false,
             now: 0,
         };
-        let r = &p.search("")[0];
+        let results = p.search("").await;
         assert!(matches!(
-            r.action,
+            results[0].action,
             SearchAction::LaunchApp { ref path } if path.contains("Brave")
         ));
     }

--- a/src-tauri/src/search/providers/browser_tabs.rs
+++ b/src-tauri/src/search/providers/browser_tabs.rs
@@ -31,12 +31,13 @@ pub struct BrowserTabsProvider<'a> {
     pub windows: &'a [WindowEntry],
 }
 
+#[async_trait::async_trait]
 impl<'a> ResultProvider for BrowserTabsProvider<'a> {
     fn name(&self) -> &'static str {
         "browser_tabs"
     }
 
-    fn search(&self, _query: &str) -> Vec<SearchResult> {
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
         let mut results = Vec::new();
         for window in self.windows {
             // Skip non-browser windows up front — the FFI call to
@@ -77,14 +78,14 @@ impl<'a> ResultProvider for BrowserTabsProvider<'a> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn empty_windows_returns_empty() {
+    #[tokio::test]
+    async fn empty_windows_returns_empty() {
         let p = BrowserTabsProvider { windows: &[] };
-        assert!(p.search("").is_empty());
+        assert!(p.search("").await.is_empty());
     }
 
-    #[test]
-    fn non_browser_processes_skipped_without_ffi_call() {
+    #[tokio::test]
+    async fn non_browser_processes_skipped_without_ffi_call() {
         // The provider should short-circuit before reaching
         // `get_browser_tabs` for non-browser processes. We can't
         // observe the FFI call directly, but we can confirm an
@@ -97,7 +98,7 @@ mod tests {
             title: "Not a browser".into(),
         }];
         let p = BrowserTabsProvider { windows: &windows };
-        assert!(p.search("").is_empty());
+        assert!(p.search("").await.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/search/providers/calculator.rs
+++ b/src-tauri/src/search/providers/calculator.rs
@@ -23,12 +23,13 @@ const CALCULATOR_SCORE: i64 = 100_000;
 
 pub struct CalculatorProvider;
 
+#[async_trait::async_trait]
 impl ResultProvider for CalculatorProvider {
     fn name(&self) -> &'static str {
         "calculator"
     }
 
-    fn search(&self, query: &str) -> Vec<SearchResult> {
+    async fn search(&self, query: &str) -> Vec<SearchResult> {
         let Some(calc) = calculator::detect(query) else {
             return Vec::new();
         };
@@ -68,26 +69,26 @@ fn build_result(calc: calculator::Calculation) -> SearchResult {
 mod tests {
     use super::*;
 
-    #[test]
-    fn non_math_query_returns_empty() {
+    #[tokio::test]
+    async fn non_math_query_returns_empty() {
         let p = CalculatorProvider;
-        assert!(p.search("hello world").is_empty());
-        assert!(p.search("apple").is_empty());
-        assert!(p.search("").is_empty());
+        assert!(p.search("hello world").await.is_empty());
+        assert!(p.search("apple").await.is_empty());
+        assert!(p.search("").await.is_empty());
     }
 
-    #[test]
-    fn arithmetic_returns_one_result() {
+    #[tokio::test]
+    async fn arithmetic_returns_one_result() {
         let p = CalculatorProvider;
-        let results = p.search("2 + 2");
+        let results = p.search("2 + 2").await;
         assert_eq!(results.len(), 1);
         let r = &results[0];
         assert!(r.name.contains("4"));
         assert_eq!(r.id, "calc:2 + 2");
     }
 
-    #[test]
-    fn copy_action_strips_currency_rate_suffix() {
+    #[tokio::test]
+    async fn copy_action_strips_currency_rate_suffix() {
         // The expected display includes "5 USD = 4.50 EUR (rates
         // from ...)" — the copyable value should be "4.50 EUR" only.
         // We can't easily mock the currency rate fetcher here, so
@@ -97,7 +98,7 @@ mod tests {
         // Just smoke-test the action shape on a deterministic
         // arithmetic case.
         let p = CalculatorProvider;
-        let results = p.search("10 * 3");
+        let results = p.search("10 * 3").await;
         assert_eq!(results.len(), 1);
         match &results[0].action {
             SearchAction::CopyClipboard { content } => {

--- a/src-tauri/src/search/providers/file_search.rs
+++ b/src-tauri/src/search/providers/file_search.rs
@@ -1,0 +1,86 @@
+//! Indexed-files provider for the `f` route.
+//!
+//! Returns recently-opened files when the route is summoned with no
+//! search term, or substring matches when a term is provided. Always
+//! appends a "Re-index files now" affordance row at the bottom so a
+//! user with an empty file index has a discoverable next step.
+//!
+//! `FileSearchManager` is sync (rusqlite's blocking API); the
+//! provider is async to fit the `ResultProvider` contract but
+//! contains no `.await` — the trait async-ness is uniform, the
+//! work doesn't have to be.
+
+use crate::files::FileSearchManager;
+use crate::search::dispatch::SubQuery;
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// Score files land on. Same level as recent notes — both are
+/// "user content the route surfaced explicitly".
+const FILE_SCORE: i64 = 10_000;
+/// "Re-index files now" affordance score — sorts to the bottom
+/// when files exist, sole result on a fresh / empty index.
+const REINDEX_SCORE: i64 = 1;
+/// Cap on how many files surface — matches the prior route
+/// implementation.
+const FILES_LIMIT: usize = 8;
+
+pub struct FileSearchProvider<'a> {
+    pub manager: &'a FileSearchManager,
+    pub sub: SubQuery,
+}
+
+#[async_trait::async_trait]
+impl<'a> ResultProvider for FileSearchProvider<'a> {
+    fn name(&self) -> &'static str {
+        "file_search"
+    }
+
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
+        let files = match &self.sub {
+            SubQuery::Listing => self.manager.get_recent(FILES_LIMIT),
+            SubQuery::Search(q) if q.is_empty() => self.manager.get_recent(FILES_LIMIT),
+            SubQuery::Search(q) => self.manager.search(q, FILES_LIMIT),
+        };
+
+        let mut out: Vec<SearchResult> = files
+            .map(|files| {
+                files
+                    .into_iter()
+                    .map(|file| SearchResult {
+                        id: file.id.clone(),
+                        name: file.name,
+                        description: file.path.clone(),
+                        icon: Some("file".to_string()),
+                        result_type: ResultType::File,
+                        score: FILE_SCORE,
+                        frecency_score: 0.0,
+                        preview: None,
+                        pinned: false,
+                        action: SearchAction::OpenFile { path: file.path },
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Always surface a "Re-index files now" affordance so users
+        // with an empty file index have a discoverable path forward.
+        out.push(SearchResult {
+            id: "file:__reindex__".to_string(),
+            name: "Re-index files now".to_string(),
+            description: "Scan the configured paths for files".to_string(),
+            icon: Some("file_reindex".to_string()),
+            result_type: ResultType::File,
+            score: REINDEX_SCORE,
+            frecency_score: 0.0,
+            preview: None,
+            pinned: false,
+            action: SearchAction::ReindexFiles,
+        });
+        out
+    }
+}
+
+// Provider behavior tests are limited because FileSearchManager is
+// DB-backed. The existing route integration tests cover the
+// recents / search / reindex-affordance behavior end-to-end.

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -16,6 +16,8 @@
 pub mod apps;
 pub mod browser_tabs;
 pub mod calculator;
+pub mod file_search;
+pub mod notes;
 pub mod snippets;
 pub mod system_commands;
 pub mod web_search;

--- a/src-tauri/src/search/providers/notes.rs
+++ b/src-tauri/src/search/providers/notes.rs
@@ -1,0 +1,151 @@
+//! Notes provider for the `n` route.
+//!
+//! Returns the user's notes — recent if no search term, fuzzy-match
+//! over title/tags/content if a term is provided. Always appends a
+//! "Create new note" affordance row at the bottom so users with zero
+//! notes still get a discoverable next step (this replaces the
+//! removed bare-`n` shortcut).
+//!
+//! Async because the underlying `NotesManager` runs SQLite I/O on a
+//! background thread (Tauri/tokio).
+
+use crate::notes::NotesManager;
+use crate::search::dispatch::SubQuery;
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+
+/// Score recent / matched notes land on. Above the apps floor (0)
+/// and the open-window score (100) so notes the user explicitly
+/// scoped to via the `n ` prefix dominate.
+const NOTE_SCORE: i64 = 10_000;
+/// "Create new note" affordance. Lower than every note row so it
+/// sorts to the bottom when notes exist, but remains visible (and
+/// is the only result) on a fresh install.
+const CREATE_NEW_NOTE_SCORE: i64 = 1;
+/// Cap on how many notes show in the route — matches the prior
+/// hand-coded path's `take(8)`.
+const NOTES_LIMIT: usize = 8;
+
+/// Clean plain-text snippet of a note's content. Strips markdown
+/// headers and collapses newlines to a single line so the preview
+/// row reads cleanly even when the content has heavy formatting.
+fn note_preview(content: &str) -> String {
+    let clean = content
+        .lines()
+        .filter(|line| !line.trim().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let clipped: String = clean.chars().take(100).collect();
+    if clean.chars().count() > 100 {
+        format!("{clipped}…")
+    } else {
+        clipped
+    }
+}
+
+pub struct NotesProvider<'a> {
+    pub manager: &'a NotesManager,
+    /// Pre-parsed sub-query from the route classifier. The provider
+    /// uses it to decide between `get_recent` and `search`.
+    pub sub: SubQuery,
+}
+
+#[async_trait::async_trait]
+impl<'a> ResultProvider for NotesProvider<'a> {
+    fn name(&self) -> &'static str {
+        "notes"
+    }
+
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
+        let notes_res = match &self.sub {
+            SubQuery::Listing => self.manager.get_recent(NOTES_LIMIT).await,
+            SubQuery::Search(q) if q.is_empty() => self.manager.get_recent(NOTES_LIMIT).await,
+            SubQuery::Search(q) => self.manager.search(q).await,
+        };
+
+        let mut out: Vec<SearchResult> = notes_res
+            .map(|notes| {
+                notes
+                    .into_iter()
+                    .take(NOTES_LIMIT)
+                    .map(|note| SearchResult {
+                        id: note.id.clone(),
+                        name: note.title,
+                        description: format!("Note · {}", note.tags.join(", ")),
+                        icon: Some("note".to_string()),
+                        result_type: ResultType::Note,
+                        score: NOTE_SCORE,
+                        frecency_score: 0.0,
+                        preview: Some(note_preview(&note.content)),
+                        pinned: false,
+                        action: SearchAction::OpenNote { note_id: note.id },
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Always surface a "Create new note" entry. Replaces the
+        // removed bare-`n` keyboard shortcut: a user with zero notes
+        // who types `n ` would otherwise see an empty list with no
+        // path forward.
+        out.push(SearchResult {
+            id: "note:__create__".to_string(),
+            name: "Create new note".to_string(),
+            description: "Open the editor with an empty note".to_string(),
+            icon: Some("note_new".to_string()),
+            result_type: ResultType::Note,
+            score: CREATE_NEW_NOTE_SCORE,
+            frecency_score: 0.0,
+            preview: None,
+            pinned: false,
+            action: SearchAction::CreateNewNote,
+        });
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_preview_strips_markdown_headers() {
+        let content = "# Heading\nSome content.\n## Sub\nMore text.";
+        let preview = note_preview(content);
+        assert!(!preview.contains("#"));
+        assert!(preview.contains("Some content."));
+        assert!(preview.contains("More text."));
+    }
+
+    #[test]
+    fn note_preview_collapses_newlines_to_spaces() {
+        let preview = note_preview("line one\nline two\nline three");
+        assert_eq!(preview, "line one line two line three");
+    }
+
+    #[test]
+    fn note_preview_truncates_long_content_with_ellipsis() {
+        let long: String = "x".repeat(150);
+        let preview = note_preview(&long);
+        assert_eq!(preview.chars().count(), 101); // 100 + ellipsis
+        assert!(preview.ends_with('…'));
+    }
+
+    #[test]
+    fn note_preview_empty_input_safe() {
+        assert_eq!(note_preview(""), "");
+    }
+
+    #[test]
+    fn note_preview_only_headers_returns_empty_or_blank() {
+        // All-header content collapses to empty after the filter.
+        let preview = note_preview("# h1\n## h2\n### h3");
+        assert!(preview.trim().is_empty());
+    }
+
+    // Provider behavior tests are limited because NotesManager is
+    // DB-backed and not easily mockable from a unit test. The route
+    // logic (sub-query → get_recent vs search → results +
+    // create-new affordance) is exercised by the existing notes
+    // route integration tests.
+}

--- a/src-tauri/src/search/providers/snippets.rs
+++ b/src-tauri/src/search/providers/snippets.rs
@@ -36,12 +36,13 @@ pub struct SnippetsProvider<'a> {
     pub manager: &'a SnippetsManager,
 }
 
+#[async_trait::async_trait]
 impl<'a> ResultProvider for SnippetsProvider<'a> {
     fn name(&self) -> &'static str {
         "snippets"
     }
 
-    fn search(&self, query: &str) -> Vec<SearchResult> {
+    async fn search(&self, query: &str) -> Vec<SearchResult> {
         // SnippetsManager::search returns Result; treat errors as
         // "no results" — same policy the prior hand-coded path used.
         // A real DB error already gets logged via the manager's own

--- a/src-tauri/src/search/providers/system_commands.rs
+++ b/src-tauri/src/search/providers/system_commands.rs
@@ -31,12 +31,13 @@ pub struct SystemCommandsProvider {
     pub sub: SubQuery,
 }
 
+#[async_trait::async_trait]
 impl ResultProvider for SystemCommandsProvider {
     fn name(&self) -> &'static str {
         "system_commands"
     }
 
-    fn search(&self, _query: &str) -> Vec<SearchResult> {
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
         let filter = match &self.sub {
             SubQuery::Listing => None,
             SubQuery::Search(q) if q.is_empty() => None,
@@ -73,12 +74,12 @@ impl ResultProvider for SystemCommandsProvider {
 mod tests {
     use super::*;
 
-    #[test]
-    fn listing_returns_every_registered_command() {
+    #[tokio::test]
+    async fn listing_returns_every_registered_command() {
         let p = SystemCommandsProvider {
             sub: SubQuery::Listing,
         };
-        let results = p.search("");
+        let results = p.search("").await;
         // Every registered command surfaces, no filter applied.
         // The exact count varies as commands are added/removed; we
         // only assert non-empty + every result has the expected
@@ -91,19 +92,22 @@ mod tests {
         }
     }
 
-    #[test]
-    fn empty_search_treated_as_listing() {
+    #[tokio::test]
+    async fn empty_search_treated_as_listing() {
         let p_listing = SystemCommandsProvider {
             sub: SubQuery::Listing,
         };
         let p_empty = SystemCommandsProvider {
             sub: SubQuery::Search(String::new()),
         };
-        assert_eq!(p_listing.search("").len(), p_empty.search("").len());
+        assert_eq!(
+            p_listing.search("").await.len(),
+            p_empty.search("").await.len()
+        );
     }
 
-    #[test]
-    fn substring_filter_matches_alias_case_insensitively() {
+    #[tokio::test]
+    async fn substring_filter_matches_alias_case_insensitively() {
         // "lock" should match the lock command's alias / name no
         // matter the case the user types. Test against a token
         // that's almost certainly in the registered commands.
@@ -113,20 +117,20 @@ mod tests {
         let p_upper = SystemCommandsProvider {
             sub: SubQuery::Search("LOCK".into()),
         };
-        let lower_results = p_lower.search("");
-        let upper_results = p_upper.search("");
+        let lower_results = p_lower.search("").await;
+        let upper_results = p_upper.search("").await;
         // Same matches regardless of case.
         assert_eq!(lower_results.len(), upper_results.len());
         // Lock command is in the registered set.
         assert!(!lower_results.is_empty(), "expected at least one lock-related command");
     }
 
-    #[test]
-    fn nonexistent_token_returns_empty() {
+    #[tokio::test]
+    async fn nonexistent_token_returns_empty() {
         let p = SystemCommandsProvider {
             sub: SubQuery::Search("zzzz-not-a-command-token".into()),
         };
-        assert!(p.search("").is_empty());
+        assert!(p.search("").await.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/search/providers/web_search.rs
+++ b/src-tauri/src/search/providers/web_search.rs
@@ -27,12 +27,13 @@ pub struct WebSearchProvider<'a> {
     pub configs: &'a [WebSearch],
 }
 
+#[async_trait::async_trait]
 impl<'a> ResultProvider for WebSearchProvider<'a> {
     fn name(&self) -> &'static str {
         "web_search"
     }
 
-    fn search(&self, query: &str) -> Vec<SearchResult> {
+    async fn search(&self, query: &str) -> Vec<SearchResult> {
         let WebSearchMatch::Matched { index, subquery } = match_web_search(query, self.configs)
         else {
             return Vec::new();
@@ -78,18 +79,18 @@ mod tests {
         }
     }
 
-    #[test]
-    fn no_match_returns_empty() {
+    #[tokio::test]
+    async fn no_match_returns_empty() {
         let configs = vec![cfg("Google", "g", "https://google.com/?q={query}")];
         let p = WebSearchProvider { configs: &configs };
-        assert!(p.search("hello world").is_empty());
+        assert!(p.search("hello world").await.is_empty());
     }
 
-    #[test]
-    fn match_returns_one_result_with_open_url_action() {
+    #[tokio::test]
+    async fn match_returns_one_result_with_open_url_action() {
         let configs = vec![cfg("Google", "g", "https://google.com/?q={query}")];
         let p = WebSearchProvider { configs: &configs };
-        let results = p.search("g rust async");
+        let results = p.search("g rust async").await;
         assert_eq!(results.len(), 1);
         let r = &results[0];
         assert_eq!(r.id, "web:g");
@@ -100,14 +101,14 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn malformed_url_template_is_silently_skipped() {
+    #[tokio::test]
+    async fn malformed_url_template_is_silently_skipped() {
         // build_web_search_url rejects non-http(s) schemes — the prior
         // path (and this provider) treats that as "no result", not as
         // an error to surface.
         let configs = vec![cfg("Bad", "b", "javascript:alert({query})")];
         let p = WebSearchProvider { configs: &configs };
-        assert!(p.search("b foo").is_empty());
+        assert!(p.search("b foo").await.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/search/providers/windows.rs
+++ b/src-tauri/src/search/providers/windows.rs
@@ -24,12 +24,13 @@ pub struct WindowsProvider<'a> {
     pub windows: &'a [WindowEntry],
 }
 
+#[async_trait::async_trait]
 impl<'a> ResultProvider for WindowsProvider<'a> {
     fn name(&self) -> &'static str {
         "windows"
     }
 
-    fn search(&self, _query: &str) -> Vec<SearchResult> {
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
         // Query intentionally ignored — fuzzy ranking lives in
         // `SearchEngine::search` downstream and handles all kinds
         // uniformly.
@@ -68,20 +69,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn empty_windows_returns_empty() {
+    #[tokio::test]
+    async fn empty_windows_returns_empty() {
         let p = WindowsProvider { windows: &[] };
-        assert!(p.search("").is_empty());
+        assert!(p.search("").await.is_empty());
     }
 
-    #[test]
-    fn each_window_becomes_one_result_with_focus_window_action() {
+    #[tokio::test]
+    async fn each_window_becomes_one_result_with_focus_window_action() {
         let windows = vec![
             win(0x100, "Project A — VS Code", "code"),
             win(0x200, "Inbox — Mail", "mail"),
         ];
         let p = WindowsProvider { windows: &windows };
-        let results = p.search("");
+        let results = p.search("").await;
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, "Project A — VS Code");
         assert!(matches!(
@@ -91,8 +92,8 @@ mod tests {
         assert_eq!(results[1].id, "win:200");
     }
 
-    #[test]
-    fn ids_are_distinct_for_different_hwnds_with_same_title() {
+    #[tokio::test]
+    async fn ids_are_distinct_for_different_hwnds_with_same_title() {
         // Multi-window apps (browser with two windows of the same
         // page title) need distinct ids or the listbox de-dupes them
         // against each other.
@@ -101,17 +102,20 @@ mod tests {
             win(0x101, "GitHub", "browser"),
         ];
         let p = WindowsProvider { windows: &windows };
-        let results = p.search("");
+        let results = p.search("").await;
         assert_eq!(results[0].id, "win:100");
         assert_eq!(results[1].id, "win:101");
         assert_ne!(results[0].id, results[1].id);
     }
 
-    #[test]
-    fn description_uses_process_name() {
+    #[tokio::test]
+    async fn description_uses_process_name() {
         let windows = vec![win(0x1, "Whatever", "Custom Process")];
         let p = WindowsProvider { windows: &windows };
-        assert_eq!(p.search("")[0].description, "Switch to Custom Process");
+        assert_eq!(
+            p.search("").await[0].description,
+            "Switch to Custom Process"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 1A final slice. Converts the trait to async-by-default via `async_trait` and migrates the two remaining providers — notes and file_search.

## What lands
- `async-trait` 0.1 dep added
- `ResultProvider::search` is now `async fn` (Send-bound to match Tauri's multi-threaded async command executor)
- All seven existing providers updated to `#[async_trait]` impls
- New `NotesProvider` and `FileSearchProvider` covering the `n` and `f` routes
- `lib.rs::search` snapshots lock-guarded state before any `.await` (RwLockReadGuard isn't Send; clone settings.web_searches + indexed_apps. Both are bounded-size, clones are cheap)
- Old route-handler free functions removed from lib.rs — their logic lives in providers now

## Migration progress: 9 of 9 ✅
| Provider | Status |
|---|---|
| web_search, snippets, apps | ✅ |
| windows, browser_tabs | ✅ |
| calculator, system_commands | ✅ |
| **notes, file_search** | ✅ this PR |

## What's NOT yet in this PR
- Dispatcher is not yet a single registry loop. Route-gated and short-circuit providers don't fit uniform iteration cleanly. Separate PR to think through routes vs unconditional providers — likely a per-route registry or a kind-filter on a single registry.

## Test plan
- [x] `cargo test --lib` — 390 pass (5 new from note_preview)
- [x] `cargo check` clean
- [ ] CI cross-platform compile