### PR TITLE
refactor(actions): migrate open_url + open_file handlers (slice 2)

### DIFF
--- a/src-tauri/src/actions/handlers/mod.rs
+++ b/src-tauri/src/actions/handlers/mod.rs
@@ -22,3 +22,5 @@
 //! Ok in the dispatcher and don't need a handler module.
 
 pub mod launch_app;
+pub mod open_file;
+pub mod open_url;

--- a/src-tauri/src/actions/handlers/open_file.rs
+++ b/src-tauri/src/actions/handlers/open_file.rs
@@ -1,0 +1,20 @@
+//! Handler for `SearchAction::OpenFile`.
+//!
+//! Records that the user opened the file (frecency for the file
+//! search index) BEFORE invoking the OS opener. Recording is
+//! best-effort — a failed write is logged but the open still
+//! proceeds. Same intent-vs-success policy as `launch_app`.
+//!
+//! Lifetime: takes a `&FileSearchManager` reference for the
+//! recording side effect. The OS-level `open::that` is platform-
+//! provided and needs no app state.
+
+use crate::files::FileSearchManager;
+
+pub fn handle(path: String, file_search: &FileSearchManager) -> Result<(), String> {
+    // WAT-304: record the open before invoking the OS so stats
+    // reflect user intent even if the OS-level open fails.
+    // Failure to record is non-fatal — the open proceeds.
+    let _ = file_search.record_open(&path);
+    open::that(&path).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/actions/handlers/open_url.rs
+++ b/src-tauri/src/actions/handlers/open_url.rs
@@ -1,0 +1,14 @@
+//! Handler for `SearchAction::OpenUrl`.
+//!
+//! Hands the URL to the OS via the existing `actions::open_url`
+//! helper (which itself runs the `validate_target` shell-injection
+//! filter and `open::that` to launch the system default browser).
+//! No state side effects — opens are stateless. Stats for web
+//! searches are not recorded today; if that becomes a feature it
+//! lands here.
+
+use crate::actions::open_url as os_open_url;
+
+pub fn handle(url: String) -> Result<(), String> {
+    os_open_url(&url)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -352,7 +352,7 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
         SearchAction::LaunchApp { path } => {
             actions::handlers::launch_app::handle(path, &state.db, &state.indexed_apps)
         }
-        SearchAction::OpenUrl { url } => actions::open_url(&url),
+        SearchAction::OpenUrl { url } => actions::handlers::open_url::handle(url),
         SearchAction::RunCommand { command } => execute_command(&command),
         SearchAction::CopyClipboard { content } => state.clipboard.copy_to_clipboard(&content),
         SearchAction::OpenNote { note_id: _ } => {
@@ -360,11 +360,7 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
             Ok(())
         }
         SearchAction::OpenFile { path } => {
-            // WAT-304: record open before invoking the OS so stats
-            // reflect user intent even if the OS-level open fails.
-            // Failure to record is non-fatal — the open proceeds.
-            let _ = state.file_search.record_open(&path);
-            open::that(&path).map_err(|e| e.to_string())
+            actions::handlers::open_file::handle(path, &state.file_search)
         }
         SearchAction::PasteSnippet { expansion } => {
             // WAT-301: two steps. (1) Put the expansion on the


### PR DESCRIPTION
Phase 1A action-handler slice 2. Same pattern as #90 — pull the per-variant logic out of `execute_action`'s match into its own module.

## What lands
- `handlers::open_url::handle` — thin delegation to the existing `actions::open_url` helper. The module exists for symmetry; if the URL path grows pre-flight validation or stats recording, it lands here without touching the dispatcher.
- `handlers::open_file::handle` — the WAT-304 `record_open` + `os_open` sequence. Takes `&FileSearchManager` for the stats side effect.
- `execute_action`'s OpenUrl + OpenFile arms shrink to one delegation each.

## Migration progress
| Handler | Status |
|---|---|
| launch_app | ✅ #90 |
| **open_url, open_file** | ✅ this PR |
| copy_clipboard | next |
| run_command, paste_snippet | |
| focus_window, focus_browser_tab | |
| reindex_files | |

## Test plan
- [x] `cargo test --lib` — 393 pass
- [x] `cargo check` clean
- [ ] CI cross-platform compile