### PR TITLE
refactor(actions): migrate copy_clipboard + run_command + paste_snippet (slice 3)

### DIFF
--- a/src-tauri/src/actions/handlers/copy_clipboard.rs
+++ b/src-tauri/src/actions/handlers/copy_clipboard.rs
@@ -1,0 +1,12 @@
+//! Handler for `SearchAction::CopyClipboard`.
+//!
+//! Single-shot copy: the dispatcher hands a string, the
+//! `ClipboardManager` writes it to the OS clipboard. No further
+//! state mutation; clipboard *history* is updated by the manager
+//! itself when the next monitor tick observes the new system value.
+
+use crate::clipboard::ClipboardManager;
+
+pub fn handle(content: String, clipboard: &ClipboardManager) -> Result<(), String> {
+    clipboard.copy_to_clipboard(&content)
+}

--- a/src-tauri/src/actions/handlers/mod.rs
+++ b/src-tauri/src/actions/handlers/mod.rs
@@ -21,6 +21,9 @@
 //! Frontend-only variants (`OpenNote`, `CreateNewNote`) stay no-op
 //! Ok in the dispatcher and don't need a handler module.
 
+pub mod copy_clipboard;
 pub mod launch_app;
 pub mod open_file;
 pub mod open_url;
+pub mod paste_snippet;
+pub mod run_command;

--- a/src-tauri/src/actions/handlers/paste_snippet.rs
+++ b/src-tauri/src/actions/handlers/paste_snippet.rs
@@ -1,0 +1,171 @@
+//! Handler for `SearchAction::PasteSnippet`.
+//!
+//! Two-step expansion: (1) put the expansion on the clipboard so it
+//! is useful even if step 2 fails; (2) synthesize Ctrl/Cmd+V into
+//! the prior-focused window. The frontend hides Watson before the
+//! IPC call so the OS focus has already returned to whatever the
+//! user was typing in.
+//!
+//! Platform paths:
+//! - Windows: Win32 `SendInput` with VK_CONTROL + VK_V virtual keys.
+//!   Replaces a prior PowerShell SendKeys shell-out that
+//!   intermittently toggled NumLock under foreground-change races
+//!   (KB179987-style behavior).
+//! - macOS: Quartz `CGEventCreateKeyboardEvent` + `CGEventPost` for
+//!   Cmd+V at the session-level tap. Uses the Accessibility grant
+//!   the switcher already requires; avoids prompting for the
+//!   separate Automation permission `osascript` would have needed.
+//! - Linux: `xdotool key ctrl+v` best-effort. If xdotool isn't
+//!   installed the snippet is already on the clipboard so the user
+//!   can paste manually with Ctrl+V.
+//!
+//! All three platforms drop the cold-start cost of spawning a
+//! scripting host (~100-150ms per paste) compared to their previous
+//! shell-out implementations.
+
+use crate::clipboard::ClipboardManager;
+
+pub fn handle(expansion: String, clipboard: &ClipboardManager) -> Result<(), String> {
+    // Step 1: copy to clipboard. Always do this, even if step 2
+    // fails — the user can paste manually as a fallback.
+    clipboard.copy_to_clipboard(&expansion)?;
+    // Step 2: OS paste.
+    paste_via_os()
+}
+
+#[cfg(target_os = "windows")]
+fn paste_via_os() -> Result<(), String> {
+    use std::thread::sleep;
+    use std::time::Duration;
+    use windows::Win32::UI::Input::KeyboardAndMouse::{
+        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS, KEYEVENTF_KEYUP,
+        VIRTUAL_KEY, VK_CONTROL, VK_V,
+    };
+
+    // Give the previously-focused window a moment to fully regain
+    // focus after Watson hides. Without this, the synthesized
+    // Ctrl+V can race the activation and land on the desktop or on
+    // Watson itself (now hidden).
+    sleep(Duration::from_millis(80));
+
+    fn key(vk: VIRTUAL_KEY, key_up: bool) -> INPUT {
+        INPUT {
+            r#type: INPUT_KEYBOARD,
+            Anonymous: INPUT_0 {
+                ki: KEYBDINPUT {
+                    wVk: vk,
+                    wScan: 0,
+                    dwFlags: if key_up {
+                        KEYEVENTF_KEYUP
+                    } else {
+                        KEYBD_EVENT_FLAGS(0)
+                    },
+                    time: 0,
+                    dwExtraInfo: 0,
+                },
+            },
+        }
+    }
+
+    // Down-down-up-up so Ctrl is held while V is struck.
+    let inputs = [
+        key(VK_CONTROL, false),
+        key(VK_V, false),
+        key(VK_V, true),
+        key(VK_CONTROL, true),
+    ];
+
+    let n = unsafe { SendInput(&inputs, std::mem::size_of::<INPUT>() as i32) };
+    if n != inputs.len() as u32 {
+        return Err(format!(
+            "SendInput accepted only {n} of {} keystrokes",
+            inputs.len()
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn paste_via_os() -> Result<(), String> {
+    use std::os::raw::c_void;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    type CGEventRef = *mut c_void;
+    type CGEventSourceRef = *mut c_void;
+    type CGEventTapLocation = u32;
+    type CGEventFlags = u64;
+    type CGKeyCode = u16;
+    type CFTypeRef = *const c_void;
+
+    /// Quartz session-level tap: posts after WindowServer processes
+    /// events but before they reach apps in the user's session. The
+    /// right level for "I'm a userland tool synthesizing input."
+    const K_CG_SESSION_EVENT_TAP: CGEventTapLocation = 1;
+    /// Modifier flag mask for Command. Apple's `CGEventFlags`
+    /// bits — `kCGEventFlagMaskCommand`.
+    const K_CG_EVENT_FLAG_MASK_COMMAND: CGEventFlags = 0x100000;
+    /// HIToolbox `kVK_ANSI_V` — the V key's layout-independent
+    /// virtual position. Cmd+V is the universal paste shortcut so
+    /// the physical position is what matters, not the user's
+    /// keyboard layout.
+    const K_VK_ANSI_V: CGKeyCode = 0x09;
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        fn CGEventCreateKeyboardEvent(
+            source: CGEventSourceRef,
+            virtual_key: CGKeyCode,
+            key_down: bool,
+        ) -> CGEventRef;
+        fn CGEventSetFlags(event: CGEventRef, flags: CGEventFlags);
+        fn CGEventPost(tap: CGEventTapLocation, event: CGEventRef);
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: CFTypeRef);
+    }
+
+    // Same 80ms grace period as the Windows path: the previously-
+    // focused window needs a beat to fully regain focus after
+    // Watson hides, otherwise the synthesized keystrokes can land
+    // on Watson itself or on the desktop.
+    sleep(Duration::from_millis(80));
+
+    unsafe fn post_v_event(key_down: bool) -> Result<(), String> {
+        let event = CGEventCreateKeyboardEvent(std::ptr::null_mut(), K_VK_ANSI_V, key_down);
+        if event.is_null() {
+            return Err(String::from(
+                "CGEventCreateKeyboardEvent returned null — Accessibility \
+                 permission probably not granted",
+            ));
+        }
+        CGEventSetFlags(event, K_CG_EVENT_FLAG_MASK_COMMAND);
+        CGEventPost(K_CG_SESSION_EVENT_TAP, event);
+        CFRelease(event as CFTypeRef);
+        Ok(())
+    }
+
+    unsafe {
+        post_v_event(true)?; // Cmd+V down
+        post_v_event(false)?; // Cmd+V up
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn paste_via_os() -> Result<(), String> {
+    // Linux best-effort. xdotool is widely available but not
+    // guaranteed; if it's missing, the snippet is already on the
+    // clipboard so the user can paste manually (Ctrl+V).
+    match std::process::Command::new("xdotool")
+        .args(["key", "--clearmodifiers", "ctrl+v"])
+        .spawn()
+    {
+        Ok(_) => Ok(()),
+        Err(e) => Err(format!(
+            "Could not synthesize paste (xdotool not found: {e}). The snippet is on your clipboard — press Ctrl+V manually."
+        )),
+    }
+}

--- a/src-tauri/src/actions/handlers/run_command.rs
+++ b/src-tauri/src/actions/handlers/run_command.rs
@@ -1,0 +1,12 @@
+//! Handler for `SearchAction::RunCommand`.
+//!
+//! Thin delegation to the existing `execute_command` helper which
+//! looks the command id up in the static registry and runs its
+//! platform-specific implementation (sleep, lock, restart, etc.).
+//! No state side effects beyond what the command itself does.
+
+use crate::actions::system::execute_command;
+
+pub fn handle(command: String) -> Result<(), String> {
+    execute_command(&command)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -353,8 +353,10 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
             actions::handlers::launch_app::handle(path, &state.db, &state.indexed_apps)
         }
         SearchAction::OpenUrl { url } => actions::handlers::open_url::handle(url),
-        SearchAction::RunCommand { command } => execute_command(&command),
-        SearchAction::CopyClipboard { content } => state.clipboard.copy_to_clipboard(&content),
+        SearchAction::RunCommand { command } => actions::handlers::run_command::handle(command),
+        SearchAction::CopyClipboard { content } => {
+            actions::handlers::copy_clipboard::handle(content, &state.clipboard)
+        }
         SearchAction::OpenNote { note_id: _ } => {
             // Note opening is handled by the frontend
             Ok(())
@@ -363,13 +365,7 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
             actions::handlers::open_file::handle(path, &state.file_search)
         }
         SearchAction::PasteSnippet { expansion } => {
-            // WAT-301: two steps. (1) Put the expansion on the
-            // clipboard — this alone is useful even if step 2 fails.
-            // (2) Synthesize Ctrl/Cmd+V into the prior-focused window.
-            // The frontend hides Watson before calling us, so focus
-            // has returned to wherever the user was typing.
-            state.clipboard.copy_to_clipboard(&expansion)?;
-            paste_snippet_via_os()
+            actions::handlers::paste_snippet::handle(expansion, &state.clipboard)
         }
         SearchAction::FocusWindow { hwnd } => actions::windows::focus_window(hwnd),
         SearchAction::FocusBrowserTab { hwnd, index } => {
@@ -401,162 +397,9 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
     }
 }
 
-/// WAT-301: platform shim for synthesizing a paste keystroke.
-/// Windows uses Win32 `SendInput` directly. macOS uses Quartz
-/// `CGEventPost` directly. Linux is best-effort via xdotool;
-/// if xdotool isn't installed, the expansion is still on the
-/// clipboard and the user can paste manually.
-///
-/// Why direct event APIs and not OS-level scripting (PowerShell
-/// SendKeys on Windows, osascript System Events on macOS):
-///
-/// - **Windows / SendKeys**: raced the foreground-window change
-///   Watson triggers when hiding, and intermittently toggled
-///   NumLock instead of pasting (KB179987-style behavior).
-/// - **macOS / osascript**: requires Automation permission, a
-///   second permission prompt on top of the Accessibility
-///   permission we already require for the switcher. CGEvent
-///   uses the Accessibility grant, so first-launch UX is
-///   one prompt instead of two.
-///
-/// Both new paths also drop the cold-start cost of spawning a
-/// scripting host (~100-150ms on every paste).
-#[cfg(target_os = "windows")]
-fn paste_snippet_via_os() -> Result<(), String> {
-    use std::thread::sleep;
-    use std::time::Duration;
-    use windows::Win32::UI::Input::KeyboardAndMouse::{
-        SendInput, INPUT, INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYBD_EVENT_FLAGS,
-        KEYEVENTF_KEYUP, VIRTUAL_KEY, VK_CONTROL, VK_V,
-    };
-
-    // Give the previously-focused window a moment to fully regain
-    // focus after Watson hides. Without this, the synthesized
-    // Ctrl+V can race the activation and land on the desktop or on
-    // Watson itself (now hidden).
-    sleep(Duration::from_millis(80));
-
-    fn key(vk: VIRTUAL_KEY, key_up: bool) -> INPUT {
-        INPUT {
-            r#type: INPUT_KEYBOARD,
-            Anonymous: INPUT_0 {
-                ki: KEYBDINPUT {
-                    wVk: vk,
-                    wScan: 0,
-                    dwFlags: if key_up {
-                        KEYEVENTF_KEYUP
-                    } else {
-                        KEYBD_EVENT_FLAGS(0)
-                    },
-                    time: 0,
-                    dwExtraInfo: 0,
-                },
-            },
-        }
-    }
-
-    // Down-down-up-up so Ctrl is held while V is struck.
-    let inputs = [
-        key(VK_CONTROL, false),
-        key(VK_V, false),
-        key(VK_V, true),
-        key(VK_CONTROL, true),
-    ];
-
-    let n = unsafe { SendInput(&inputs, std::mem::size_of::<INPUT>() as i32) };
-    if n != inputs.len() as u32 {
-        return Err(format!(
-            "SendInput accepted only {n} of {} keystrokes",
-            inputs.len()
-        ));
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn paste_snippet_via_os() -> Result<(), String> {
-    use std::os::raw::c_void;
-    use std::thread::sleep;
-    use std::time::Duration;
-
-    type CGEventRef = *mut c_void;
-    type CGEventSourceRef = *mut c_void;
-    type CGEventTapLocation = u32;
-    type CGEventFlags = u64;
-    type CGKeyCode = u16;
-    type CFTypeRef = *const c_void;
-
-    /// Quartz session-level tap: posts after WindowServer processes
-    /// events but before they reach apps in the user's session. The
-    /// right level for "I'm a userland tool synthesizing input."
-    const K_CG_SESSION_EVENT_TAP: CGEventTapLocation = 1;
-    /// Modifier flag mask for Command. Apple's `CGEventFlags`
-    /// bits — `kCGEventFlagMaskCommand`.
-    const K_CG_EVENT_FLAG_MASK_COMMAND: CGEventFlags = 0x100000;
-    /// HIToolbox `kVK_ANSI_V` — the V key's layout-independent
-    /// virtual position. Cmd+V is the universal paste shortcut so
-    /// the physical position is what matters, not the user's
-    /// keyboard layout.
-    const K_VK_ANSI_V: CGKeyCode = 0x09;
-
-    #[link(name = "ApplicationServices", kind = "framework")]
-    extern "C" {
-        fn CGEventCreateKeyboardEvent(
-            source: CGEventSourceRef,
-            virtual_key: CGKeyCode,
-            key_down: bool,
-        ) -> CGEventRef;
-        fn CGEventSetFlags(event: CGEventRef, flags: CGEventFlags);
-        fn CGEventPost(tap: CGEventTapLocation, event: CGEventRef);
-    }
-
-    #[link(name = "CoreFoundation", kind = "framework")]
-    extern "C" {
-        fn CFRelease(cf: CFTypeRef);
-    }
-
-    // Same 80ms grace period as the Windows path: the previously-
-    // focused window needs a beat to fully regain focus after
-    // Watson hides, otherwise the synthesized keystrokes can land
-    // on Watson itself or on the desktop.
-    sleep(Duration::from_millis(80));
-
-    unsafe fn post_v_event(key_down: bool) -> Result<(), String> {
-        let event = CGEventCreateKeyboardEvent(std::ptr::null_mut(), K_VK_ANSI_V, key_down);
-        if event.is_null() {
-            return Err(String::from(
-                "CGEventCreateKeyboardEvent returned null — Accessibility \
-                 permission probably not granted",
-            ));
-        }
-        CGEventSetFlags(event, K_CG_EVENT_FLAG_MASK_COMMAND);
-        CGEventPost(K_CG_SESSION_EVENT_TAP, event);
-        CFRelease(event as CFTypeRef);
-        Ok(())
-    }
-
-    unsafe {
-        post_v_event(true)?; // Cmd+V down
-        post_v_event(false)?; // Cmd+V up
-    }
-    Ok(())
-}
-
-#[cfg(not(any(target_os = "windows", target_os = "macos")))]
-fn paste_snippet_via_os() -> Result<(), String> {
-    // Linux best-effort. `xdotool` is widely available but not
-    // guaranteed; if it's missing, the snippet is already on the
-    // clipboard so the user can paste manually (Ctrl+V).
-    match std::process::Command::new("xdotool")
-        .args(["key", "--clearmodifiers", "ctrl+v"])
-        .spawn()
-    {
-        Ok(_) => Ok(()),
-        Err(e) => Err(format!(
-            "Could not synthesize paste (xdotool not found: {e}). The snippet is on your clipboard — press Ctrl+V manually."
-        )),
-    }
-}
+// Phase 1A: paste_snippet_via_os relocated to
+// `actions::handlers::paste_snippet`. The dispatcher delegates
+// via the handler module now.
 
 #[tauri::command]
 fn hide_window(window: tauri::WebviewWindow) {


### PR DESCRIPTION
Phase 1A action-handler slice 3. Three handlers in one PR — they share the same shape (each pulls one match arm out of execute_action) and none has substantial new logic to test.

## What lands
- `handlers::copy_clipboard::handle` — single-shot delegation to `ClipboardManager::copy_to_clipboard`.
- `handlers::run_command::handle` — thin delegation to `actions::system::execute_command`.
- `handlers::paste_snippet::handle` — relocates the entire `paste_snippet_via_os` platform-gated implementation (Win32 SendInput / Quartz CGEventPost / xdotool) plus the clipboard-copy step. `lib.rs` no longer carries any keystroke-synthesis code.
- `execute_action`'s three corresponding arms shrink to one delegation each.

## Migration progress
| Handler | Status |
|---|---|
| launch_app, open_url, open_file | ✅ |
| **copy_clipboard, run_command, paste_snippet** | ✅ this PR |
| focus_window, focus_browser_tab, reindex_files | next (final slice) |

After the next slice merges, `execute_action` becomes a thin dispatcher (~30 lines) and we do the **local-test session** to verify no behavior drift across the action surface.

## Test plan
- [x] `cargo test --lib` — 393 pass
- [x] `cargo check` clean
- [ ] CI cross-platform compile