### PR TITLE
refactor(actions): migrate focus_window + focus_browser_tab + reindex_files (final slice)

### DIFF
--- a/src-tauri/src/actions/handlers/focus_browser_tab.rs
+++ b/src-tauri/src/actions/handlers/focus_browser_tab.rs
@@ -1,0 +1,13 @@
+//! Handler for `SearchAction::FocusBrowserTab`.
+//!
+//! Cross-platform browser-tab activation delegated to the existing
+//! `actions::browser_tabs::focus_browser_tab` (UIA on Windows, AX
+//! tree walk on macOS, AT-SPI on Linux). The handler exists for
+//! symmetry with the rest of the action surface; if tab focus
+//! grows pre-flight checks or telemetry, that lands here.
+
+use crate::actions::browser_tabs::focus_browser_tab as os_focus_browser_tab;
+
+pub fn handle(hwnd: i64, index: i32) -> Result<(), String> {
+    os_focus_browser_tab(hwnd, index)
+}

--- a/src-tauri/src/actions/handlers/focus_window.rs
+++ b/src-tauri/src/actions/handlers/focus_window.rs
@@ -1,0 +1,14 @@
+//! Handler for `SearchAction::FocusWindow`.
+//!
+//! Cross-platform window focus delegated to the existing
+//! `actions::windows::focus_window` (Win32 SetForegroundWindow +
+//! AttachThreadInput on Windows; AX `kAXRaiseAction` +
+//! `NSRunningApplication.activate` on macOS; EWMH
+//! `_NET_ACTIVE_WINDOW` ClientMessage on X11; wlr-foreign-toplevel
+//! `activate` on wlroots Wayland).
+
+use crate::actions::windows::focus_window as os_focus_window;
+
+pub fn handle(hwnd: i64) -> Result<(), String> {
+    os_focus_window(hwnd)
+}

--- a/src-tauri/src/actions/handlers/mod.rs
+++ b/src-tauri/src/actions/handlers/mod.rs
@@ -22,8 +22,11 @@
 //! Ok in the dispatcher and don't need a handler module.
 
 pub mod copy_clipboard;
+pub mod focus_browser_tab;
+pub mod focus_window;
 pub mod launch_app;
 pub mod open_file;
 pub mod open_url;
 pub mod paste_snippet;
+pub mod reindex_files;
 pub mod run_command;

--- a/src-tauri/src/actions/handlers/reindex_files.rs
+++ b/src-tauri/src/actions/handlers/reindex_files.rs
@@ -1,0 +1,39 @@
+//! Handler for `SearchAction::ReindexFiles`.
+//!
+//! Triggered by the empty-state "Re-index files now" affordance the
+//! `f` route surfaces. Validates that file search is enabled in
+//! settings (rejecting with a typed error if not), resets the
+//! indexer's cancellation token, builds a fresh `FileIndexer` from
+//! the configured paths / exclusions / max depth, and runs a full
+//! sweep.
+//!
+//! Lifetime: takes the `&FileSearchManager` (Arc-cloned for the
+//! indexer) plus the snapshot of settings the indexer needs. The
+//! caller (`execute_action`) holds the settings RwLock briefly to
+//! pull these values; cloning is cheap (Vec<String> + a couple of
+//! primitives) and avoids holding the guard across the indexer's
+//! work.
+
+use std::sync::Arc;
+
+use crate::config::settings::FileSearchSettings;
+use crate::files::indexer::FileIndexer;
+use crate::files::FileSearchManager;
+
+pub fn handle(
+    file_search: Arc<FileSearchManager>,
+    file_search_settings: FileSearchSettings,
+) -> Result<(), String> {
+    if !file_search_settings.enabled {
+        return Err("File search is disabled in Settings".to_string());
+    }
+    file_search.reset_cancel();
+    let indexer = FileIndexer::new(
+        file_search,
+        file_search_settings.indexed_paths,
+        file_search_settings.excluded_patterns,
+        file_search_settings.max_depth,
+    );
+    indexer.index_all();
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -367,9 +367,9 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
         SearchAction::PasteSnippet { expansion } => {
             actions::handlers::paste_snippet::handle(expansion, &state.clipboard)
         }
-        SearchAction::FocusWindow { hwnd } => actions::windows::focus_window(hwnd),
+        SearchAction::FocusWindow { hwnd } => actions::handlers::focus_window::handle(hwnd),
         SearchAction::FocusBrowserTab { hwnd, index } => {
-            actions::browser_tabs::focus_browser_tab(hwnd, index)
+            actions::handlers::focus_browser_tab::handle(hwnd, index)
         }
         // Frontend handles `CreateNewNote` directly (opens the editor
         // panel). If it ever reaches the backend, that's a frontend
@@ -380,19 +380,13 @@ fn execute_action(action: SearchAction, state: State<AppState>) -> Result<(), St
         // results once this returns so the newly-indexed files
         // surface immediately.
         SearchAction::ReindexFiles => {
-            let settings = state.settings.read().unwrap();
-            if !settings.file_search.enabled {
-                return Err("File search is disabled in Settings".to_string());
-            }
-            state.file_search.reset_cancel();
-            let indexer = files::indexer::FileIndexer::new(
+            // Snapshot the file_search settings so we don't hold the
+            // RwLockReadGuard across the indexer call.
+            let file_search_settings = state.settings.read().unwrap().file_search.clone();
+            actions::handlers::reindex_files::handle(
                 Arc::clone(&state.file_search),
-                settings.file_search.indexed_paths.clone(),
-                settings.file_search.excluded_patterns.clone(),
-                settings.file_search.max_depth,
-            );
-            indexer.index_all();
-            Ok(())
+                file_search_settings,
+            )
         }
     }
 }


### PR DESCRIPTION
Phase 1A action-handler migration **complete**. The three remaining match arms in `execute_action` move to per-variant modules, collapsing the dispatcher to a thin set of one-line delegations.

## What lands
- `handlers::focus_window::handle` — delegates to `actions::windows::focus_window`.
- `handlers::focus_browser_tab::handle` — delegates to `actions::browser_tabs::focus_browser_tab`.
- `handlers::reindex_files::handle` — takes `Arc<FileSearchManager>` + a cloned `FileSearchSettings` (snapshotted from the lock so the indexer doesn't run with a guard held). Validates `settings.enabled`, resets cancel, builds FileIndexer, runs `index_all`.
- `execute_action`'s three corresponding arms shrink to one delegation each. Dispatcher is now ~42 lines (down from ~80 pre-refactor).

## Migration complete: 9 of 9 handlers ✅
| Handler | Status |
|---|---|
| launch_app, open_url, open_file | ✅ |
| copy_clipboard, run_command, paste_snippet | ✅ |
| **focus_window, focus_browser_tab, reindex_files** | ✅ this PR |

## After merge: local-test session
Spot-check each action type to confirm no behavior drift. Suggested checklist (~5 min):
- Launch an app from search → opens, frecency increments
- Trigger a web search via keyword → opens in default browser
- Open a file from `f` route → opens, recents get the entry
- Switch to an open window → focuses correctly
- Switch to a browser tab → activates that tab + brings the browser forward
- Copy a clipboard entry → pastes correctly elsewhere
- Run a system command (e.g. `>lock`) → triggers the OS action
- Trigger a snippet (`;trigger`) → expansion pastes into prior window
- `f __reindex__` → re-indexes without erroring

## Test plan
- [x] `cargo test --lib` — 393 pass
- [x] `cargo check` clean
- [ ] CI cross-platform compile
- [ ] Local action-surface spot-check after merge