### PR TITLE
feat(capture): unify notes + snippets + clipboard behind Capture trait + new cap route

### DIFF
--- a/src-tauri/src/capture.rs
+++ b/src-tauri/src/capture.rs
@@ -1,0 +1,299 @@
+//! Capture model — Phase 1A.
+//!
+//! Notes, snippets, and clipboard entries are three of Watson's "user
+//! text" features that previously had zero shared abstraction. Each
+//! had its own manager with its own listing/search shape; the new
+//! `cap`/`captures` route would have meant three bespoke traversals.
+//!
+//! `Capture` is the unifying interface: every captured-text entry
+//! exposes `id / kind / title / content / created_at / modified_at /
+//! tags`. The dispatcher iterates a single `&[Box<dyn Capture>]`-shaped
+//! aggregator instead of switching on kind.
+//!
+//! Scratchpad is intentionally absent: per the Phase 1A cuts in
+//! DESIGN.md, scratchpad is folding into "untitled note", which means
+//! the existing `Note` impl will cover it once the migration lands.
+//! Adding a transient `CaptureKind::Scratchpad` here would be
+//! abstraction we'd then have to remove.
+
+use serde::{Deserialize, Serialize};
+
+use crate::clipboard::ClipboardEntry;
+use crate::notes::Note;
+use crate::search::SearchAction;
+use crate::snippets::Snippet;
+
+/// Discriminator for the underlying entry type. The provider uses
+/// this to pick the right `SearchAction` and icon when it materializes
+/// a `Capture` into a `SearchResult`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureKind {
+    Note,
+    Snippet,
+    Clipboard,
+}
+
+impl CaptureKind {
+    /// Stable icon slug the frontend resolves to a glyph.
+    pub fn icon(&self) -> &'static str {
+        match self {
+            CaptureKind::Note => "note",
+            CaptureKind::Snippet => "snippet",
+            CaptureKind::Clipboard => "clipboard",
+        }
+    }
+}
+
+/// Common read-shape for any captured text entry. Implementations
+/// borrow from the underlying entry struct; the provider clones into
+/// a `CaptureView` only when it needs to cross an ownership boundary.
+pub trait Capture {
+    fn id(&self) -> &str;
+    fn kind(&self) -> CaptureKind;
+    /// Human-readable label for the result row. For notes this is the
+    /// note title; for snippets the trigger; for clipboard entries a
+    /// trimmed one-line synopsis of the content.
+    fn title(&self) -> &str;
+    /// The full captured text. Used for substring matching in the
+    /// provider's search path and for the result row's preview.
+    fn content(&self) -> &str;
+    fn created_at(&self) -> i64;
+    fn modified_at(&self) -> i64;
+    /// Free-form tags. Empty for entry types that don't carry tags
+    /// (snippets, clipboard).
+    fn tags(&self) -> Vec<String>;
+}
+
+/// Concrete, owned, serializable form of a `Capture`. The provider
+/// aggregates entries into `CaptureView`s so it can sort and ship a
+/// single `Vec<SearchResult>` back to the dispatcher without holding
+/// borrows across the async boundary.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureView {
+    pub id: String,
+    pub kind: CaptureKind,
+    pub title: String,
+    pub content: String,
+    pub created_at: i64,
+    pub modified_at: i64,
+    pub tags: Vec<String>,
+}
+
+impl Capture for CaptureView {
+    fn id(&self) -> &str { &self.id }
+    fn kind(&self) -> CaptureKind { self.kind }
+    fn title(&self) -> &str { &self.title }
+    fn content(&self) -> &str { &self.content }
+    fn created_at(&self) -> i64 { self.created_at }
+    fn modified_at(&self) -> i64 { self.modified_at }
+    fn tags(&self) -> Vec<String> { self.tags.clone() }
+}
+
+impl Capture for Note {
+    fn id(&self) -> &str { &self.id }
+    fn kind(&self) -> CaptureKind { CaptureKind::Note }
+    fn title(&self) -> &str { &self.title }
+    fn content(&self) -> &str { &self.content }
+    fn created_at(&self) -> i64 { self.created_at }
+    fn modified_at(&self) -> i64 { self.modified_at }
+    fn tags(&self) -> Vec<String> { self.tags.clone() }
+}
+
+impl Capture for Snippet {
+    fn id(&self) -> &str { &self.id }
+    fn kind(&self) -> CaptureKind { CaptureKind::Snippet }
+    /// Trigger is the canonical label — it's what the user types to
+    /// invoke the snippet, so it's the most-recognizable identifier
+    /// in the result row.
+    fn title(&self) -> &str { &self.trigger }
+    /// The expansion is what gets pasted, which is what the user is
+    /// searching the body of when they go looking for a snippet.
+    fn content(&self) -> &str { &self.expansion }
+    fn created_at(&self) -> i64 { self.created_at }
+    fn modified_at(&self) -> i64 { self.modified_at }
+    fn tags(&self) -> Vec<String> { Vec::new() }
+}
+
+impl Capture for ClipboardEntry {
+    fn id(&self) -> &str { &self.id }
+    fn kind(&self) -> CaptureKind { CaptureKind::Clipboard }
+    /// Clipboard entries have no first-class title. The stored
+    /// `preview` is already a short, single-line synopsis suitable
+    /// for the row label.
+    fn title(&self) -> &str { &self.preview }
+    fn content(&self) -> &str { &self.content }
+    fn created_at(&self) -> i64 { self.timestamp.timestamp() }
+    fn modified_at(&self) -> i64 { self.timestamp.timestamp() }
+    fn tags(&self) -> Vec<String> { Vec::new() }
+}
+
+/// Convert a `Capture` into the `SearchAction` that activates it.
+/// Each kind reuses the existing per-kind action so the executor
+/// path stays untouched.
+pub fn capture_action(view: &CaptureView) -> SearchAction {
+    match view.kind {
+        CaptureKind::Note => SearchAction::OpenNote {
+            note_id: view.id.clone(),
+        },
+        CaptureKind::Snippet => SearchAction::PasteSnippet {
+            expansion: view.content.clone(),
+        },
+        CaptureKind::Clipboard => SearchAction::CopyClipboard {
+            content: view.content.clone(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
+
+    fn fixed_ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).single().expect("valid ts")
+    }
+
+    fn note(id: &str, title: &str, content: &str) -> Note {
+        Note {
+            id: id.into(),
+            title: title.into(),
+            content: content.into(),
+            tags: vec!["work".into()],
+            created_at: 1_000,
+            modified_at: 2_000,
+            external_changes: None,
+        }
+    }
+
+    fn snippet(id: &str, trigger: &str, expansion: &str) -> Snippet {
+        Snippet {
+            id: id.into(),
+            trigger: trigger.into(),
+            name: "label".into(),
+            expansion: expansion.into(),
+            created_at: 1_000,
+            modified_at: 2_000,
+        }
+    }
+
+    fn clip(id: &str, content: &str, preview: &str) -> ClipboardEntry {
+        ClipboardEntry {
+            id: id.into(),
+            content: content.into(),
+            preview: preview.into(),
+            timestamp: fixed_ts(3_000),
+            pinned: false,
+        }
+    }
+
+    #[test]
+    fn note_capture_surface_matches_underlying_fields() {
+        let n = note("note:1", "Meeting", "body");
+        assert_eq!(n.id(), "note:1");
+        assert_eq!(n.kind(), CaptureKind::Note);
+        assert_eq!(n.title(), "Meeting");
+        assert_eq!(n.content(), "body");
+        assert_eq!(n.created_at(), 1_000);
+        assert_eq!(n.modified_at(), 2_000);
+        assert_eq!(n.tags(), vec!["work".to_string()]);
+    }
+
+    #[test]
+    fn snippet_uses_trigger_as_title_and_expansion_as_content() {
+        // The provider's title/content split has to match what
+        // CapturesProvider relies on for substring matching: searching
+        // for the trigger should hit `title()`, searching the body
+        // should hit `content()`.
+        let s = snippet("snip:1", ";addr", "123 Main St");
+        assert_eq!(s.title(), ";addr");
+        assert_eq!(s.content(), "123 Main St");
+        assert_eq!(s.kind(), CaptureKind::Snippet);
+        assert!(s.tags().is_empty());
+    }
+
+    #[test]
+    fn clipboard_uses_preview_as_title_and_timestamp_for_both_dates() {
+        // Clipboard entries don't carry a separate modified_at, so
+        // both Capture::created_at and Capture::modified_at fall back
+        // to the same timestamp. This test pins that behavior — if we
+        // ever add an edit-on-pin feature, modified_at will need a
+        // new field on ClipboardEntry too.
+        let c = clip("clip:1", "https://example.com/long-url", "https://example.com/lo…");
+        assert_eq!(c.title(), "https://example.com/lo…");
+        assert_eq!(c.content(), "https://example.com/long-url");
+        assert_eq!(c.kind(), CaptureKind::Clipboard);
+        assert_eq!(c.created_at(), c.modified_at());
+    }
+
+    #[test]
+    fn capture_view_round_trips_through_clone() {
+        let view = CaptureView {
+            id: "note:1".into(),
+            kind: CaptureKind::Note,
+            title: "Title".into(),
+            content: "Body".into(),
+            created_at: 1,
+            modified_at: 2,
+            tags: vec!["t".into()],
+        };
+        assert_eq!(view.id(), "note:1");
+        assert_eq!(view.kind(), CaptureKind::Note);
+        assert_eq!(view.tags(), vec!["t".to_string()]);
+    }
+
+    #[test]
+    fn capture_action_dispatches_per_kind() {
+        let note_view = CaptureView {
+            id: "note:42".into(),
+            kind: CaptureKind::Note,
+            title: "t".into(),
+            content: "c".into(),
+            created_at: 0,
+            modified_at: 0,
+            tags: vec![],
+        };
+        assert!(matches!(
+            capture_action(&note_view),
+            SearchAction::OpenNote { note_id } if note_id == "note:42"
+        ));
+
+        let snip_view = CaptureView {
+            id: "snip:1".into(),
+            kind: CaptureKind::Snippet,
+            title: ";x".into(),
+            content: "expanded".into(),
+            created_at: 0,
+            modified_at: 0,
+            tags: vec![],
+        };
+        assert!(matches!(
+            capture_action(&snip_view),
+            SearchAction::PasteSnippet { expansion } if expansion == "expanded"
+        ));
+
+        let clip_view = CaptureView {
+            id: "clip:1".into(),
+            kind: CaptureKind::Clipboard,
+            title: "p".into(),
+            content: "pasteable".into(),
+            created_at: 0,
+            modified_at: 0,
+            tags: vec![],
+        };
+        assert!(matches!(
+            capture_action(&clip_view),
+            SearchAction::CopyClipboard { content } if content == "pasteable"
+        ));
+    }
+
+    #[test]
+    fn icon_slug_per_kind_is_stable() {
+        // Icon slugs cross the IPC boundary into the frontend's icon
+        // resolver. Pin them so a rename here doesn't silently break
+        // the row glyph in production.
+        assert_eq!(CaptureKind::Note.icon(), "note");
+        assert_eq!(CaptureKind::Snippet.icon(), "snippet");
+        assert_eq!(CaptureKind::Clipboard.icon(), "clipboard");
+    }
+}

--- a/src-tauri/src/config/tests.rs
+++ b/src-tauri/src/config/tests.rs
@@ -39,7 +39,7 @@ mod tests {
     /// `local_reserved_prefixes_fixture_matches_canonical` below, so any
     /// drift between the two is caught.
     const RESERVED_PREFIXES: &[&str] =
-        &["n", "notes", "f", "files", "cb", "clip", "s", ">"];
+        &["n", "notes", "f", "files", "cb", "clip", "cap", "captures", "s", ">"];
 
     #[test]
     fn default_settings_match_documented_contract() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod actions;
 mod apps;
 mod calculator;
+mod capture;
 mod clipboard;
 mod config;
 mod db;
@@ -30,6 +31,7 @@ use search::provider::ResultProvider;
 use search::providers::apps::AppsProvider;
 use search::providers::browser_tabs::BrowserTabsProvider;
 use search::providers::calculator::CalculatorProvider;
+use search::providers::captures::CapturesProvider;
 use search::providers::file_search::FileSearchProvider;
 use search::providers::notes::NotesProvider;
 use search::providers::snippets::SnippetsProvider;
@@ -244,6 +246,16 @@ async fn search(query: String, state: State<'_, AppState>) -> Result<Vec<SearchR
         Route::Clipboard(sub) => return Ok(clipboard_route_results(&state, sub)),
         Route::SystemCommands(sub) => {
             return Ok(SystemCommandsProvider { sub }.search(&query).await)
+        }
+        Route::Captures(sub) => {
+            return Ok(CapturesProvider {
+                notes: &state.notes,
+                snippets: &state.snippets,
+                clipboard: &state.clipboard,
+                sub,
+            }
+            .search(&query)
+            .await)
         }
         Route::Passthrough => {}
     }

--- a/src-tauri/src/search/dispatch.rs
+++ b/src-tauri/src/search/dispatch.rs
@@ -25,7 +25,7 @@ use crate::config::settings::WebSearch;
 
 /// Reserved query prefixes that short-circuit before web-search keyword matching.
 /// Using one of these as a web-search keyword makes that web search unreachable.
-pub const RESERVED_PREFIXES: &[&str] = &["n", "notes", "f", "files", "cb", "clip"];
+pub const RESERVED_PREFIXES: &[&str] = &["n", "notes", "f", "files", "cb", "clip", "cap", "captures"];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Route {
@@ -36,6 +36,12 @@ pub enum Route {
     /// WAT-306: `>` alone lists all system commands; `>foo` filters them.
     /// Exclusive route — apps and web searches are not mixed in.
     SystemCommands(SubQuery),
+    /// Phase 1A capture model: aggregated view across notes, snippets,
+    /// and clipboard entries. Sorted by recency. The `cap` / `captures`
+    /// prefix activates this route exclusively (no apps / web mixed
+    /// in) so the user can scan everything they've recently captured
+    /// without route-hopping.
+    Captures(SubQuery),
     /// Not a reserved-prefix route. Caller should check web-search match next,
     /// then fall through to general fuzzy-match over apps / commands / web.
     Passthrough,
@@ -80,6 +86,7 @@ pub fn classify_prefix_route(query: &str) -> Route {
         "n" | "notes" => return Route::Notes(SubQuery::Listing),
         "f" | "files" => return Route::Files(SubQuery::Listing),
         "cb" | "clip" => return Route::Clipboard(SubQuery::Listing),
+        "cap" | "captures" => return Route::Captures(SubQuery::Listing),
         _ => {}
     }
 
@@ -92,6 +99,9 @@ pub fn classify_prefix_route(query: &str) -> Route {
     }
     if let Some(sub) = strip_one_of(query, &["cb ", "clip "]) {
         return Route::Clipboard(SubQuery::Search(sub.to_string()));
+    }
+    if let Some(sub) = strip_one_of(query, &["cap ", "captures "]) {
+        return Route::Captures(SubQuery::Search(sub.to_string()));
     }
 
     Route::Passthrough
@@ -361,10 +371,46 @@ mod tests {
                     Route::Notes(SubQuery::Listing)
                         | Route::Files(SubQuery::Listing)
                         | Route::Clipboard(SubQuery::Listing)
+                        | Route::Captures(SubQuery::Listing)
                 ),
                 "RESERVED_PREFIXES entry '{prefix}' did not classify to a listing route: {route:?}",
             );
         }
+    }
+
+    // --- Phase 1A capture model: `cap` / `captures` route ---
+
+    #[test]
+    fn bare_cap_and_captures_are_captures_listing() {
+        assert_eq!(
+            classify_prefix_route("cap"),
+            Route::Captures(SubQuery::Listing)
+        );
+        assert_eq!(
+            classify_prefix_route("captures"),
+            Route::Captures(SubQuery::Listing)
+        );
+    }
+
+    #[test]
+    fn cap_space_subquery_is_captures_search() {
+        assert_eq!(
+            classify_prefix_route("cap address"),
+            Route::Captures(SubQuery::Search("address".into()))
+        );
+        assert_eq!(
+            classify_prefix_route("captures address"),
+            Route::Captures(SubQuery::Search("address".into()))
+        );
+    }
+
+    #[test]
+    fn word_starting_with_cap_is_not_a_captures_prefix() {
+        // `capacity`, `capture` (no `s`), `cape` etc. would otherwise
+        // collide with the new prefix. The exact-match listing path
+        // and the prefix-with-space search path together prevent that.
+        assert_eq!(classify_prefix_route("capacity"), Route::Passthrough);
+        assert_eq!(classify_prefix_route("capricorn"), Route::Passthrough);
     }
 
     // --- match_web_search ---

--- a/src-tauri/src/search/providers/captures.rs
+++ b/src-tauri/src/search/providers/captures.rs
@@ -1,0 +1,296 @@
+//! Unified-captures provider for the `cap` / `captures` route.
+//!
+//! Aggregates over the three capture-shaped managers (notes, snippets,
+//! clipboard) and returns a single, time-sorted list. Listing mode
+//! pulls the most-recently-touched N from each, merges, and trims to
+//! `MAX_CAPTURE_RESULTS`. Search mode runs each manager's own search
+//! against the substring and merges the same way.
+//!
+//! Sort key: `modified_at` desc — recency is the most useful default
+//! when "what was I just working on?" is the question. Within a tie
+//! we don't impose a kind preference; the merge is stable so the
+//! manager iteration order (notes, snippets, clipboard) breaks ties
+//! quietly.
+
+use crate::capture::{capture_action, Capture, CaptureKind, CaptureView};
+use crate::clipboard::ClipboardManager;
+use crate::notes::NotesManager;
+use crate::search::dispatch::SubQuery;
+use crate::search::provider::ResultProvider;
+use crate::search::{ResultType, SearchAction, SearchResult};
+use crate::snippets::SnippetsManager;
+
+/// Score captures land on. Same as the notes route — captures is an
+/// exclusive route so apps/web-search aren't mixed in, but the score
+/// floor matters for the ResultsList comparator's secondary fallback.
+const CAPTURE_SCORE: i64 = 10_000;
+
+/// Per-manager pull cap during listing mode. Three managers × 8 = up
+/// to 24 captures pre-merge, post-merge trimmed to MAX_CAPTURE_RESULTS.
+const PER_KIND_LIMIT: usize = 8;
+
+/// Final result-list cap shown to the user.
+const MAX_CAPTURE_RESULTS: usize = 12;
+
+/// Single-line preview of a capture's content for the result row.
+/// Strips markdown headers, collapses newlines, truncates with an
+/// ellipsis. Intentionally identical in spirit to `note_preview` /
+/// `snippet_preview`; keeping it inline here avoids cross-provider
+/// imports and lets the captures route apply uniform truncation.
+fn capture_preview(content: &str) -> String {
+    let clean = content
+        .lines()
+        .filter(|line| !line.trim().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let clipped: String = clean.chars().take(100).collect();
+    if clean.chars().count() > 100 {
+        format!("{clipped}…")
+    } else {
+        clipped
+    }
+}
+
+/// Description prefix per kind. Surfaces "Note · …", "Snippet · …",
+/// "Clipboard · …" so the user can see at a glance which subsystem
+/// the row came from.
+fn kind_label(kind: CaptureKind) -> &'static str {
+    match kind {
+        CaptureKind::Note => "Note",
+        CaptureKind::Snippet => "Snippet",
+        CaptureKind::Clipboard => "Clipboard",
+    }
+}
+
+pub struct CapturesProvider<'a> {
+    pub notes: &'a NotesManager,
+    pub snippets: &'a SnippetsManager,
+    pub clipboard: &'a ClipboardManager,
+    pub sub: SubQuery,
+}
+
+#[async_trait::async_trait]
+impl<'a> ResultProvider for CapturesProvider<'a> {
+    fn name(&self) -> &'static str {
+        "captures"
+    }
+
+    async fn search(&self, _query: &str) -> Vec<SearchResult> {
+        let views = match &self.sub {
+            SubQuery::Listing => self.collect_recent().await,
+            SubQuery::Search(q) if q.is_empty() => self.collect_recent().await,
+            SubQuery::Search(q) => self.collect_matches(q).await,
+        };
+
+        views.into_iter().map(view_to_result).collect()
+    }
+}
+
+impl<'a> CapturesProvider<'a> {
+    async fn collect_recent(&self) -> Vec<CaptureView> {
+        let mut views: Vec<CaptureView> = Vec::new();
+
+        if let Ok(notes) = self.notes.get_recent(PER_KIND_LIMIT).await {
+            views.extend(notes.iter().map(note_to_view));
+        }
+        if let Ok(snippets) = self.snippets.list() {
+            views.extend(snippets.iter().take(PER_KIND_LIMIT).map(snippet_to_view));
+        }
+        let clips = self.clipboard.get_history();
+        views.extend(clips.iter().take(PER_KIND_LIMIT).map(clip_to_view));
+
+        sort_and_trim(views)
+    }
+
+    async fn collect_matches(&self, query: &str) -> Vec<CaptureView> {
+        let mut views: Vec<CaptureView> = Vec::new();
+
+        if let Ok(notes) = self.notes.search(query).await {
+            views.extend(notes.iter().map(note_to_view));
+        }
+        if let Ok(snippets) = self.snippets.search(query) {
+            views.extend(snippets.iter().map(snippet_to_view));
+        }
+        let clips = self.clipboard.search_history(query);
+        views.extend(clips.iter().map(clip_to_view));
+
+        sort_and_trim(views)
+    }
+}
+
+fn note_to_view(n: &crate::notes::Note) -> CaptureView {
+    CaptureView {
+        id: n.id().to_string(),
+        kind: n.kind(),
+        title: n.title().to_string(),
+        content: n.content().to_string(),
+        created_at: n.created_at(),
+        modified_at: n.modified_at(),
+        tags: n.tags(),
+    }
+}
+
+fn snippet_to_view(s: &crate::snippets::Snippet) -> CaptureView {
+    CaptureView {
+        id: s.id().to_string(),
+        kind: s.kind(),
+        title: s.title().to_string(),
+        content: s.content().to_string(),
+        created_at: s.created_at(),
+        modified_at: s.modified_at(),
+        tags: s.tags(),
+    }
+}
+
+fn clip_to_view(c: &crate::clipboard::ClipboardEntry) -> CaptureView {
+    CaptureView {
+        id: c.id().to_string(),
+        kind: c.kind(),
+        title: c.title().to_string(),
+        content: c.content().to_string(),
+        created_at: c.created_at(),
+        modified_at: c.modified_at(),
+        tags: c.tags(),
+    }
+}
+
+fn sort_and_trim(mut views: Vec<CaptureView>) -> Vec<CaptureView> {
+    // Stable sort so equal modified_ats preserve insertion order
+    // (notes → snippets → clipboard). Reverse for desc.
+    views.sort_by(|a, b| b.modified_at.cmp(&a.modified_at));
+    views.truncate(MAX_CAPTURE_RESULTS);
+    views
+}
+
+fn view_to_result(view: CaptureView) -> SearchResult {
+    let preview = capture_preview(&view.content);
+    let description = if view.tags.is_empty() {
+        format!("{} · {}", kind_label(view.kind), preview)
+    } else {
+        format!("{} · {}", kind_label(view.kind), view.tags.join(", "))
+    };
+    let action = capture_action(&view);
+    SearchResult {
+        id: view.id.clone(),
+        name: view.title,
+        description,
+        icon: Some(view.kind.icon().to_string()),
+        result_type: capture_result_type(view.kind),
+        score: CAPTURE_SCORE,
+        frecency_score: 0.0,
+        preview: Some(preview),
+        pinned: false,
+        action,
+    }
+}
+
+fn capture_result_type(kind: CaptureKind) -> ResultType {
+    match kind {
+        CaptureKind::Note => ResultType::Note,
+        CaptureKind::Snippet => ResultType::Snippet,
+        CaptureKind::Clipboard => ResultType::Clipboard,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view(kind: CaptureKind, id: &str, modified_at: i64) -> CaptureView {
+        CaptureView {
+            id: id.into(),
+            kind,
+            title: format!("title-{id}"),
+            content: format!("content-{id}"),
+            created_at: modified_at - 100,
+            modified_at,
+            tags: vec![],
+        }
+    }
+
+    #[test]
+    fn sort_and_trim_orders_by_modified_at_desc() {
+        let views = vec![
+            view(CaptureKind::Note, "a", 100),
+            view(CaptureKind::Snippet, "b", 300),
+            view(CaptureKind::Clipboard, "c", 200),
+        ];
+        let sorted = sort_and_trim(views);
+        let ids: Vec<String> = sorted.iter().map(|v| v.id.clone()).collect();
+        assert_eq!(ids, vec!["b".to_string(), "c".to_string(), "a".to_string()]);
+    }
+
+    #[test]
+    fn sort_and_trim_caps_at_max_results() {
+        // Ensure the trim runs after the sort so the OLDEST entries
+        // get dropped, never the most-recently-touched ones.
+        let mut views = Vec::new();
+        for i in 0..(MAX_CAPTURE_RESULTS as i64 + 5) {
+            views.push(view(CaptureKind::Note, &format!("n{i}"), i));
+        }
+        let sorted = sort_and_trim(views);
+        assert_eq!(sorted.len(), MAX_CAPTURE_RESULTS);
+        // Newest (highest modified_at) survives.
+        assert_eq!(sorted.first().unwrap().modified_at, MAX_CAPTURE_RESULTS as i64 + 4);
+        // Oldest five got dropped.
+        let oldest_kept = sorted.last().unwrap().modified_at;
+        assert!(oldest_kept >= 5);
+    }
+
+    #[test]
+    fn view_to_result_uses_kind_for_icon_and_result_type() {
+        let v = view(CaptureKind::Snippet, "snip:1", 0);
+        let r = view_to_result(v);
+        assert_eq!(r.icon.as_deref(), Some("snippet"));
+        assert!(matches!(r.result_type, ResultType::Snippet));
+    }
+
+    #[test]
+    fn view_to_result_action_routes_per_kind() {
+        let note_view = view(CaptureKind::Note, "note:1", 0);
+        let r = view_to_result(note_view);
+        assert!(matches!(r.action, SearchAction::OpenNote { .. }));
+
+        let clip_view = view(CaptureKind::Clipboard, "clip:1", 0);
+        let r = view_to_result(clip_view);
+        assert!(matches!(r.action, SearchAction::CopyClipboard { .. }));
+
+        let snip_view = view(CaptureKind::Snippet, "snip:1", 0);
+        let r = view_to_result(snip_view);
+        assert!(matches!(r.action, SearchAction::PasteSnippet { .. }));
+    }
+
+    #[test]
+    fn view_to_result_description_uses_tags_when_present_else_preview() {
+        let mut v = view(CaptureKind::Note, "n", 0);
+        v.tags = vec!["work".into(), "urgent".into()];
+        let with_tags = view_to_result(v);
+        assert!(with_tags.description.contains("work, urgent"));
+
+        let v2 = view(CaptureKind::Note, "n2", 0);
+        let no_tags = view_to_result(v2);
+        // Falls back to a preview snippet of the content.
+        assert!(no_tags.description.contains("content-n2"));
+    }
+
+    #[test]
+    fn capture_preview_strips_markdown_headers() {
+        let content = "# Heading\nSome content.\n## Sub\nMore text.";
+        let preview = capture_preview(content);
+        assert!(!preview.contains("#"));
+        assert!(preview.contains("Some content."));
+    }
+
+    #[test]
+    fn capture_preview_truncates_long_content_with_ellipsis() {
+        let long: String = "x".repeat(150);
+        let preview = capture_preview(&long);
+        assert_eq!(preview.chars().count(), 101);
+        assert!(preview.ends_with('…'));
+    }
+
+    // Provider-level integration (live managers) is exercised through
+    // the existing notes / snippets / clipboard route tests. Adding a
+    // duplicate harness here would re-test the underlying managers
+    // without exercising new code paths.
+}

--- a/src-tauri/src/search/providers/mod.rs
+++ b/src-tauri/src/search/providers/mod.rs
@@ -16,6 +16,7 @@
 pub mod apps;
 pub mod browser_tabs;
 pub mod calculator;
+pub mod captures;
 pub mod file_search;
 pub mod notes;
 pub mod snippets;

--- a/src/stores/__tests__/reservedPrefixes.test.ts
+++ b/src/stores/__tests__/reservedPrefixes.test.ts
@@ -31,7 +31,7 @@ describe('store.loadReservedPrefixes (WAT-205)', () => {
 
   it('populates reservedPrefixes from the backend get_reserved_prefixes command', async () => {
     mockInvoke.mockImplementation(async (cmd: string) => {
-      if (cmd === 'get_reserved_prefixes') return ['n', 'notes', 'f', 'files', 'cb', 'clip', 's', '>'];
+      if (cmd === 'get_reserved_prefixes') return ['n', 'notes', 'f', 'files', 'cb', 'clip', 'cap', 'captures', 's', '>'];
       return undefined;
     });
 
@@ -41,10 +41,11 @@ describe('store.loadReservedPrefixes (WAT-205)', () => {
     expect(state.reservedPrefixes).toContain('n');
     expect(state.reservedPrefixes).toContain('>');
     expect(state.reservedPrefixes).toContain('s');
+    expect(state.reservedPrefixes).toContain('cap');
     // Length check is a sanity guard — if the Rust side adds a prefix, the
     // Vitest mock here needs updating too, and this assertion will nudge
     // the person making the change.
-    expect(state.reservedPrefixes).toHaveLength(8);
+    expect(state.reservedPrefixes).toHaveLength(10);
   });
 
   it('leaves reservedPrefixes untouched when the backend call fails', async () => {


### PR DESCRIPTION
Phase 1A capture-model slice from DESIGN.md. Notes, snippets, and clipboard entries are three of Watson's user-text features that previously had zero shared abstraction, which meant "search across all my captured text" required three route-hops or a hand-written aggregator. This lands the abstraction and the route together — the aggregator is the trait's first consumer, so it isn't speculative scaffolding.

## What lands

**`capture.rs`**
- `CaptureKind { Note, Snippet, Clipboard }`
- `trait Capture { id, kind, title, content, created_at, modified_at, tags }` impls on `Note`, `Snippet`, `ClipboardEntry`, and the owned `CaptureView`.
- `capture_action(view) -> SearchAction` mapping each kind to the existing per-kind action so the executor path is untouched.

**`search/providers/captures.rs`**

Aggregator over the three managers.
- **Listing**: pulls 8 most-recent per kind, merges, caps at 12.
- **Search**: runs each manager's own substring matcher, merges, caps at 12.
- **Sort**: `modified_at` desc; stable so manager order (notes → snippets → clipboard) breaks ties quietly.

**Routing**
- `Route::Captures(SubQuery)` in `dispatch.rs`.
- Reserved prefixes `cap` and `captures`. Chose these over bare `c` to avoid collisions with common search starts like "calculator", "code", "cargo". Both bare-prefix listing (`cap`) and search (`cap address`) forms covered.
- `RESERVED_PREFIXES` extended → `user_reserved_prefixes()` picks up additions automatically. Frontend reservedPrefixes mock + length assertion bumped 8 → 10.
- `lib.rs::search` registers `CapturesProvider` between Clipboard and SystemCommands.

## Why scratchpad isn't here

DESIGN.md cuts scratchpad → "untitled note" — the existing Note impl will cover it once that migration lands. Adding a transient `CaptureKind::Scratchpad` would be abstraction we'd then have to remove.

## Tests

- `cargo test --lib`: **409 pass** (was 393; +16 across capture trait + captures provider).
- Frontend: **106 pass**.
- Dispatcher: new tests for `cap` / `captures` listing + search routing, plus a passthrough guard for `capacity` / `capricorn`.

## Test plan

- [x] `cargo test --lib`: 409 pass
- [x] `npx vitest run`: 106 pass
- [ ] CI cross-platform compile
- [ ] Local: type `cap` → recents from all three kinds; type `cap <word>` → mixed results; each kind activates correctly (note / paste / copy)
